### PR TITLE
[WIP] Add Profile / Challenge Lookup for the logged in user.

### DIFF
--- a/data/quests.js
+++ b/data/quests.js
@@ -910,6 +910,9 @@ module.exports = {
   "Quest:quest_br_damage_explosiveweapon": {
     name: "Deal damage with Explosive Weapons to opponents",
     count: 500,
+    free: true,
+    hard: false,
+    reward: 5,
     backendNames: ["completion_battlepass_damage_athena_player_explosives"]
   },
   "Quest:quest_br_damage_minigun": {
@@ -982,6 +985,9 @@ module.exports = {
   "Quest:quest_br_dance_scavengerhunt_danceoff": {
     name: "Dance Off with another player near Loot Lake",
     count: 1,
+    free: false,
+    hard: false,
+    reward: 5,
     backendNames: ["completion_battlepass_dance_athena_scavengerhunt_platforms"]
   },
   "Quest:quest_br_dance_scavengerhunt_forbidden": {
@@ -1108,6 +1114,9 @@ module.exports = {
   "Quest:quest_br_eliminate_location_tomatotemple": {
     name: "Eliminate opponents in Tomato Temple",
     count: 3,
+    free: false,
+    hard: true,
+    reward: 10,
     backendNames: [
       "completion_battlepass_killingblow_athena_player_tomatotemple"
     ]
@@ -1165,6 +1174,9 @@ module.exports = {
   "Quest:quest_br_eliminate_weapon_assaultrifle": {
     name: "Assault Rifle Eliminations",
     count: 5,
+    free: false,
+    hard: true,
+    reward: 10,
     backendNames: ["completion_battlepass_killingblow_athena_player_assault"]
   },
   "Quest:quest_br_eliminate_weapon_crossbow": {
@@ -1263,6 +1275,9 @@ module.exports = {
   "Quest:quest_br_interact_chests_location_pleasantpark": {
     name: "Search Chests in Pleasant Park",
     count: 7,
+    free: false,
+    hard: false,
+    reward: 5,
     backendNames: [
       "completion_battlepass_interact_athena_treasurechest_pleasantpark"
     ]
@@ -1476,6 +1491,9 @@ module.exports = {
   "Quest:quest_br_interact_scavengerhunt_treasuremap_05": {
     name: "Follow the treasure map found in Shifty Shafts",
     count: 1,
+    free: true,
+    hard: true,
+    reward: 10,
     backendNames: ["completion_battlepass_interact_athena_hidden_star_09"]
   },
   "Quest:quest_br_interact_scavengerhunt_triangulate_05": {
@@ -1792,6 +1810,9 @@ module.exports = {
   "Quest:quest_br_use_atk": {
     name: "Use an ATK (All Terrain Kart)",
     count: 1,
+    reward: 5,
+    free: true,
+    hard: false,
     backendNames: ["completion_battlepass_athena_use_golfcart"]
   },
   "Quest:quest_br_use_bush": {

--- a/data/quests.js
+++ b/data/quests.js
@@ -5,14 +5,15 @@ module.exports = {
     count: 500,
     hard: false,
     free: true,
-    countPrefix: "completion_battlepass_damage_athena_player_smg"
+    backendNames: ["completion_battlepass_damage_athena_player_smg"]
   },
   "Quest:quest_br_interact_supplyllamas": {
     name: "Search a Supply Llama",
     reward: 5,
     count: 1,
     hard: false,
-    free: true
+    free: true,
+    backendNames: ["completion_battlepass_open_athena_supply_llama"]
   },
   "Quest:quest_br_eliminate_thrownweapon": {
     name: "Clinger, Stink Bomb, or Grenade Eliminations",
@@ -20,8 +21,9 @@ module.exports = {
     count: 3,
     hard: true,
     free: true,
-    countPrefix:
+    backendNames: [
       "completion_battlepass_killingblow_athena_player_with_thrownweapon"
+    ]
   },
   "Quest:quest_br_interact_chests_location_snobbyshores": {
     name: "Search Chests in Snobby Shores",
@@ -29,8 +31,9 @@ module.exports = {
     count: 7,
     hard: false,
     free: false,
-    countPrefix:
+    backendNames: [
       "completion_battlepass_interact_athena_treasurechest_snobbyshores"
+    ]
   },
   "Quest:quest_br_interact_floating_object": {
     name: "Search floating Lightning Bolts",
@@ -38,14 +41,36 @@ module.exports = {
     count: 7,
     hard: false,
     free: false,
-    countPrefix: "completion_battlepass_athena_generic_collect_a_"
+    backendNames: [
+      "completion_battlepass_athena_generic_collect_a",
+      "completion_battlepass_athena_generic_collect_a_01",
+      "completion_battlepass_athena_generic_collect_a_02",
+      "completion_battlepass_athena_generic_collect_a_03",
+      "completion_battlepass_athena_generic_collect_a_04",
+      "completion_battlepass_athena_generic_collect_a_05",
+      "completion_battlepass_athena_generic_collect_a_06",
+      "completion_battlepass_athena_generic_collect_a_07",
+      "completion_battlepass_athena_generic_collect_a_08",
+      "completion_battlepass_athena_generic_collect_a_09",
+      "completion_battlepass_athena_generic_collect_a_10",
+      "completion_battlepass_athena_generic_collect_a_11",
+      "completion_battlepass_athena_generic_collect_a_12",
+      "completion_battlepass_athena_generic_collect_a_13",
+      "completion_battlepass_athena_generic_collect_a_14",
+      "completion_battlepass_athena_generic_collect_a_15",
+      "completion_battlepass_athena_generic_collect_a_16",
+      "completion_battlepass_athena_generic_collect_a_17",
+      "completion_battlepass_athena_generic_collect_a_18",
+      "completion_battlepass_athena_generic_collect_a_19"
+    ]
   },
   "Quest:quest_br_interact_scavengerhunt_treasuremap_01": {
     name: "Follow the treasure map found in Risky Reels",
     reward: 10,
     count: 1,
     hard: true,
-    free: false
+    free: false,
+    backendNames: ["completion_battlepass_interact_athena_hidden_star_01"]
   },
   "Quest:quest_br_eliminate_location_retailrow": {
     name: "Eliminate opponents in Retail Row",
@@ -53,7 +78,7 @@ module.exports = {
     count: 3,
     hard: true,
     free: false,
-    countPrefix: "completion_battlepass_killingblow_athena_player_retailrow"
+    backendNames: ["completion_battlepass_killingblow_athena_player_retailrow"]
   },
   "Quest:quest_br_damage_assaultrifle": {
     name: "Deal damage with Assault Rifles to opponents",
@@ -61,7 +86,7 @@ module.exports = {
     count: 1000,
     hard: false,
     free: true,
-    countPrefix: "completion_battlepass_damage_athena_player_asssult"
+    backendNames: ["completion_battlepass_damage_athena_player_asssult"]
   },
   "Quest:quest_br_interact_ammoboxes_singlematch": {
     name: "Search 7 Ammo Boxes in a single match",
@@ -69,7 +94,7 @@ module.exports = {
     count: 7,
     hard: false,
     free: true,
-    countPrefix: "completion_athena_battlepass_loot_ammobox_singlematch"
+    backendNames: ["completion_bAthenaMustCompleteInSingleMatch"]
   },
   "Quest:quest_br_eliminate_location_paradisepalms": {
     name: "Eliminate opponents in Paradise Palms",
@@ -77,7 +102,9 @@ module.exports = {
     count: 3,
     hard: true,
     free: true,
-    countPrefix: "completion_battlepass_killingblow_athena_player_paradisepalms"
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_paradisepalms"
+    ]
   },
   "Quest:quest_br_score_baskets": {
     name: "Score a 3 point shot at different basketball courts",
@@ -85,7 +112,19 @@ module.exports = {
     count: 5,
     hard: false,
     free: false,
-    countPrefix: "completion_battlepass_athena_score_basket_"
+    backendNames: [
+      "completion_battlepass_athena_score_basket",
+      "completion_battlepass_athena_score_basket_01",
+      "completion_battlepass_athena_score_basket_02",
+      "completion_battlepass_athena_score_basket_03",
+      "completion_battlepass_athena_score_basket_04",
+      "completion_battlepass_athena_score_basket_05",
+      "completion_battlepass_athena_score_basket_06",
+      "completion_battlepass_athena_score_basket_07",
+      "completion_battlepass_athena_score_basket_08",
+      "completion_battlepass_athena_score_basket_09",
+      "completion_battlepass_athena_score_basket_10"
+    ]
   },
   "Quest:quest_br_interact_chests_location_lootlake": {
     name: "Search Chests in Loot Lake",
@@ -93,14 +132,17 @@ module.exports = {
     count: 7,
     hard: false,
     free: false,
-    countPrefix: "completion_battlepass_interact_athena_treasurechest_lootlake"
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_lootlake"
+    ]
   },
   "Quest:quest_br_interact_scavengerhunt_triangulate_01": {
     name: "Search between an Oasis, Rock Archway, and Dinosaurs",
     reward: 10,
     count: 1,
     hard: true,
-    free: false
+    free: false,
+    backendNames: ["completion_battlepass_interact_athena_hidden_star_02"]
   },
   "Quest:quest_br_eliminate_weapon_sniperrifle": {
     name: "Sniper Rifle Eliminations",
@@ -108,7 +150,7 @@ module.exports = {
     count: 2,
     hard: true,
     free: false,
-    countPrefix: "completion_battlepass_killingblow_athena_player_sniper"
+    backendNames: ["completion_battlepass_killingblow_athena_player_sniper"]
   },
   "Quest:quest_br_damage_singlematch": {
     name: "Deal damage to opponents in a single match",
@@ -116,21 +158,26 @@ module.exports = {
     count: 500,
     hard: false,
     free: true,
-    countPrefix: "completion_battlepass_damage_athena_player_single_match"
+    backendNames: [
+      "completion_bAthenaMustCompleteInSingleMatch",
+      "completion_battlepass_damage_athena_player_single_match"
+    ]
   },
   "Quest:quest_br_use_launchpad": {
     name: "Use a Launchpad",
     reward: 5,
     count: 1,
     hard: false,
-    free: true
+    free: true,
+    backendNames: ["completion_battlepass_interact_athena_jumppad"]
   },
   "Quest:quest_br_interact_scavengerhunt_treasuremap_02": {
     name: "Follow the treasure map found in Flush Factory",
     reward: 10,
     count: 1,
     hard: true,
-    free: true
+    free: true,
+    backendNames: ["completion_battlepass_interact_athena_hidden_star_03"]
   },
   "Quest:quest_br_interact_chests_location_fatalfields": {
     name: "Search Chests in Fatal Fields",
@@ -138,8 +185,9 @@ module.exports = {
     count: 7,
     hard: false,
     free: false,
-    countPrefix:
+    backendNames: [
       "completion_battlepass_interact_athena_treasurechest_fatalfields"
+    ]
   },
   "Quest:quest_br_destroy_specifictargets": {
     name: "Shoot a Clay Pigeon at different locations",
@@ -147,7 +195,14 @@ module.exports = {
     count: 5,
     hard: false,
     free: false,
-    countPrefix: "completion_battlepass_destroy_specifictargets_"
+    backendNames: [
+      "completion_battlepass_destroy_specifictargets_01",
+      "completion_battlepass_destroy_specifictargets_02",
+      "completion_battlepass_destroy_specifictargets_03",
+      "completion_battlepass_destroy_specifictargets_04",
+      "completion_battlepass_destroy_specifictargets_05",
+      "completion_battlepass_destroy_specifictargets_06"
+    ]
   },
   "Quest:quest_br_eliminate_location_hauntedhills": {
     name: "Eliminate opponents in Haunted Hills",
@@ -155,7 +210,9 @@ module.exports = {
     count: 5,
     hard: true,
     free: false,
-    countPrefix: "completion_battlepass_killingblow_athena_player_hauntedhills"
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_hauntedhills"
+    ]
   },
   "Quest:quest_br_eliminate_explosiveweapon": {
     name: "Explosive Weapon Eliminations",
@@ -163,8 +220,9 @@ module.exports = {
     count: 3,
     hard: true,
     free: false,
-    countPrefix:
+    backendNames: [
       "completion_battlepass_killingblow_athena_player_with_explosives"
+    ]
   },
   "Quest:quest_br_build_structures": {
     name: "Build Structures",
@@ -172,7 +230,7 @@ module.exports = {
     count: 250,
     hard: false,
     free: true,
-    countPrefix: "completion_battlepass_build_athena_structures_any"
+    backendNames: ["completion_battlepass_build_athena_structures_any"]
   },
   "Quest:quest_br_touch_flamingrings_vehicle": {
     name: "Jump through flaming hoops with a Shopping Cart or ATK",
@@ -180,7 +238,19 @@ module.exports = {
     count: 5,
     hard: false,
     free: true,
-    countPrefix: "completion_battlepass_touch_flamingrings_vehicle_"
+    backendNames: [
+      "completion_battlepass_touch_flamingrings_vehicle",
+      "completion_battlepass_touch_flamingrings_vehicle_01",
+      "completion_battlepass_touch_flamingrings_vehicle_02",
+      "completion_battlepass_touch_flamingrings_vehicle_03",
+      "completion_battlepass_touch_flamingrings_vehicle_04",
+      "completion_battlepass_touch_flamingrings_vehicle_05",
+      "completion_battlepass_touch_flamingrings_vehicle_06",
+      "completion_battlepass_touch_flamingrings_vehicle_07",
+      "completion_battlepass_touch_flamingrings_vehicle_08",
+      "completion_battlepass_touch_flamingrings_vehicle_09",
+      "completion_battlepass_touch_flamingrings_vehicle_10"
+    ]
   },
   "Quest:quest_br_eliminate_location_dustydivot": {
     name: "Eliminate opponents in Dusty Divot",
@@ -188,7 +258,7 @@ module.exports = {
     count: 3,
     hard: true,
     free: true,
-    countPrefix: "completion_battlepass_killingblow_athena_player_dustydivot"
+    backendNames: ["completion_battlepass_killingblow_athena_player_dustydivot"]
   },
   "Quest:quest_br_damage_sniperrifle": {
     name: "Deal damage with Sniper Rifles to opponents",
@@ -196,7 +266,7 @@ module.exports = {
     count: 500,
     hard: false,
     free: false,
-    countPrefix: "completion_battlepass_damage_athena_player_sniper"
+    backendNames: ["completion_battlepass_Damage_athena_player_sniper"]
   },
   "Quest:quest_br_interact_chests_location_flushfactory": {
     name: "Search Chests in Flush Factory",
@@ -204,15 +274,17 @@ module.exports = {
     count: 7,
     hard: false,
     free: false,
-    countPrefix:
+    backendNames: [
       "completion_battlepass_interact_athena_treasurechest_flushfactory"
+    ]
   },
   "Quest:quest_br_interact_scavengerhunt_triangulate_02": {
     name: "Search between a Gas Station, Soccer Pitch, and Stunt Mountain",
     reward: 10,
     count: 1,
     hard: true,
-    free: false
+    free: false,
+    backendNames: ["completion_battlepass_interact_athena_hidden_star_04"]
   },
   "Quest:quest_br_eliminate_weapon_pistol": {
     name: "Pistol Eliminations",
@@ -220,7 +292,7 @@ module.exports = {
     count: 3,
     hard: true,
     free: false,
-    countPrefix: "completion_battlepass_killingblow_athena_player_pistol"
+    backendNames: ["completion_battlepass_killingblow_athena_player_pistol"]
   },
   "Quest:quest_br_interact_chests_location_junkjunction": {
     name: "Search Chests in Junk Junction",
@@ -228,8 +300,9 @@ module.exports = {
     count: 7,
     hard: false,
     free: true,
-    countPrefix:
+    backendNames: [
       "completion_battlepass_interact_athena_treasurechest_junkjunction"
+    ]
   },
   "Quest:quest_br_use_riftportals": {
     name: "Use Rifts or Rifts-To-Go",
@@ -237,7 +310,7 @@ module.exports = {
     count: 3,
     hard: false,
     free: true,
-    countPrefix: "completion_battlepass_touch_athena_riftportal"
+    backendNames: ["completion_battlepass_touch_athena_riftportal"]
   },
   "Quest:quest_br_eliminate_singlematch": {
     name: "Eliminate Opponents In a Single Match",
@@ -245,7 +318,10 @@ module.exports = {
     count: 3,
     hard: true,
     free: true,
-    countPrefix: "completion_battlepass_killingblow_athena_players"
+    backendNames: [
+      "completion_bAthenaMustCompleteInSingleMatch",
+      "completion_battlepass_killingblow_athena_players"
+    ]
   },
   "Quest:quest_br_damage_thrownweapons": {
     name: "Deal damage to players with a Clinger, Stink Bomb, or Grenade",
@@ -253,7 +329,7 @@ module.exports = {
     count: 300,
     hard: false,
     free: false,
-    countPrefix: "completion_battlepass_damage_athena_player_thrownweapon"
+    backendNames: ["completion_battlepass_damage_athena_player_thrownweapon"]
   },
   "Quest:quest_br_score_teetogreen": {
     name: "Hit a golf ball from tee to green on different holes",
@@ -261,14 +337,25 @@ module.exports = {
     count: 5,
     hard: false,
     free: false,
-    countPrefix: "completion_battlepass_athena_score_hole_"
+    backendNames: [
+      "completion_battlepass_athena_score_hole_01",
+      "completion_battlepass_athena_score_hole_02",
+      "completion_battlepass_athena_score_hole_03",
+      "completion_battlepass_athena_score_hole_04",
+      "completion_battlepass_athena_score_hole_05",
+      "completion_battlepass_athena_score_hole_06",
+      "completion_battlepass_athena_score_hole_07",
+      "completion_battlepass_athena_score_hole_08",
+      "completion_battlepass_athena_score_hole_09"
+    ]
   },
   "Quest:quest_br_interact_scavengerhunt_treasuremap_03": {
     name: "Follow the treasure map found in Snobby Shores",
     reward: 10,
     count: 1,
     hard: true,
-    free: false
+    free: false,
+    backendNames: ["completion_battlepass_interact_athena_hidden_star_05"]
   },
   "Quest:quest_br_eliminate_location_shiftyshafts": {
     name: "Eliminate opponents in Shifty Shafts",
@@ -276,7 +363,9 @@ module.exports = {
     count: 3,
     hard: true,
     free: false,
-    countPrefix: "completion_battlepass_killingblow_athena_player_shiftyshafts"
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_shiftyshafts"
+    ]
   },
   "Quest:quest_br_damage_headshot": {
     name: "Deal Headshot Damage to opponents",
@@ -284,7 +373,7 @@ module.exports = {
     count: 500,
     hard: false,
     free: true,
-    countPrefix: "completion_battlepass_damage_athena_player_head_shots"
+    backendNames: ["completion_battlepass_damage_athena_player_head_shots"]
   },
   "Quest:quest_br_collect_buildingresources": {
     name: "Harvest building resources with a pickaxe",
@@ -292,14 +381,15 @@ module.exports = {
     count: 3000,
     hard: false,
     free: true,
-    countPrefix: "completion_battlepass_collect_building_resources"
+    backendNames: ["completion_battlepass_collect_building_resources"]
   },
   "Quest:quest_br_interact_scavengerhunt_triangulate_03": {
     name: "Search where the Stone Heads are looking",
     reward: 10,
     count: 1,
     hard: true,
-    free: true
+    free: true,
+    backendNames: ["completion_battlepass_interact_athena_hidden_star_06"]
   },
   "Quest:quest_br_interact_chests_location_lonelylodge": {
     name: "Search Chests in Lonely Lodge",
@@ -307,8 +397,9 @@ module.exports = {
     count: 7,
     hard: false,
     free: false,
-    countPrefix:
+    backendNames: [
       "completion_battlepass_interact_athena_treasurechest_lonelylodge"
+    ]
   },
   "Quest:quest_br_timed_trials": {
     name: "Complete timed trials",
@@ -316,7 +407,15 @@ module.exports = {
     count: 5,
     hard: false,
     free: false,
-    countPrefix: "completion_battlepass_complete_timed_trials_"
+    backendNames: [
+      "completion_battlepass_complete_timed_trials_01",
+      "completion_battlepass_complete_timed_trials_02",
+      "completion_battlepass_complete_timed_trials_03",
+      "completion_battlepass_complete_timed_trials_04",
+      "completion_battlepass_complete_timed_trials_05",
+      "completion_battlepass_complete_timed_trials_06",
+      "completion_battlepass_complete_timed_trials_07"
+    ]
   },
   "Quest:quest_br_eliminate_weapon_minigunlmg": {
     name: "Minigun or Light Machine Gun Eliminations",
@@ -324,7 +423,7 @@ module.exports = {
     count: 2,
     hard: true,
     free: false,
-    countPrefix: "completion_battlepass_killingblow_athena_player_minigunlmg"
+    backendNames: ["completion_battlepass_killingblow_athena_player_minigunlmg"]
   },
   "Quest:quest_br_eliminate_location_tiltedtowers": {
     name: "Eliminate opponents in Tilted Towers",
@@ -332,7 +431,9 @@ module.exports = {
     count: 3,
     hard: true,
     free: false,
-    countPrefix: "completion_battlepass_killingblow_athena_player_tiltedtowers"
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_tiltedtowers"
+    ]
   },
   "Quest:quest_br_visit_namedlocations_singlematch": {
     name: "Visit different Named Locations in a single match",
@@ -340,7 +441,29 @@ module.exports = {
     count: 4,
     hard: false,
     free: true,
-    countPrefix: "completion_battlepass_visit_athena_location_"
+    backendNames: [
+      "completion_bAthenaMustCompleteInSingleMatch",
+      "completion_battlepass_visit_athena_location_dustydivot",
+      "completion_battlepass_visit_athena_location_fatalfields",
+      "completion_battlepass_visit_athena_location_flushfactory",
+      "completion_battlepass_visit_athena_location_greasygrove",
+      "completion_battlepass_visit_athena_location_hauntedhills",
+      "completion_battlepass_visit_athena_location_junkjunction",
+      "completion_battlepass_visit_athena_location_lazylinks",
+      "completion_battlepass_visit_athena_location_lonelylodge",
+      "completion_battlepass_visit_athena_location_lootlake",
+      "completion_battlepass_visit_athena_location_luckylanding",
+      "completion_battlepass_visit_athena_location_paradisepalms",
+      "completion_battlepass_visit_athena_location_pleasantpark",
+      "completion_battlepass_visit_athena_location_retailrow",
+      "completion_battlepass_visit_athena_location_riskyreels",
+      "completion_battlepass_visit_athena_location_saltysprings",
+      "completion_battlepass_visit_athena_location_shiftyshafts",
+      "completion_battlepass_visit_athena_location_snobbyshores",
+      "completion_battlepass_visit_athena_location_tiltedtowers",
+      "completion_battlepass_visit_athena_location_tomatotemple",
+      "completion_battlepass_visit_athena_location_wailingwoods"
+    ]
   },
   "Quest:quest_br_interact_supplydrops": {
     name: "Search Supply Drops",
@@ -348,7 +471,7 @@ module.exports = {
     count: 3,
     hard: false,
     free: true,
-    countPrefix: "completion_battlepass_interact_athena_supply_drop"
+    backendNames: ["completion_battlepass_interact_athena_supply_drop"]
   },
   "Quest:quest_br_eliminate_weapon_smg": {
     name: "SMG Eliminations",
@@ -356,7 +479,7 @@ module.exports = {
     count: 3,
     hard: true,
     free: true,
-    countPrefix: "completion_battlepass_killingblow_athena_player_smg"
+    backendNames: ["completion_battlepass_killingblow_athena_player_smg"]
   },
   "Quest:quest_br_damage_enemy_buildings_c4": {
     name: "Deal damage to opponents structures with Remote Explosives",
@@ -364,49 +487,65 @@ module.exports = {
     count: 8000,
     hard: false,
     free: false,
-    countPrefix: "completion_battlepass_damage_athena_player_buildings_c4"
+    backendNames: ["completion_battlepass_Damage_athena_player_buildings_c4"]
   },
   "Quest:quest_br_interact_chests_questchain_01_a": {
     name: "Stage 1: Search a Chest in Pleasant Park",
     reward: 1,
     count: 1,
     hard: false,
-    free: false
+    free: false,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_questchain_pleasantpark"
+    ]
   },
   "Quest:quest_br_interact_chests_questchain_01_b": {
     name: "Stage 2: Search a Chest in Retail Row",
     reward: 1,
     count: 1,
     hard: false,
-    free: false
+    free: false,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_questchain_retailrow"
+    ]
   },
   "Quest:quest_br_interact_chests_questchain_01_c": {
     name: "Stage 3: Search a Chest in Lucky Landing",
     reward: 1,
     count: 1,
     hard: false,
-    free: false
+    free: false,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_questchain_luckylanding"
+    ]
   },
   "Quest:quest_br_interact_chests_questchain_01_d": {
     name: "Stage 4: Search a Chest in Greasy Grove",
     reward: 1,
     count: 1,
     hard: false,
-    free: false
+    free: false,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_questchain_greasygrove"
+    ]
   },
   "Quest:quest_br_interact_chests_questchain_01_e": {
     name: "Final Stage: Search a Chest in Paradise Palms",
     reward: 1,
     count: 1,
     hard: false,
-    free: false
+    free: false,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_questchain_paradisepalms"
+    ]
   },
   "Quest:quest_br_interact_scavengerhunt_treasuremap_04": {
     name: "Follow the treasure map found in Dusty Divot",
     reward: 10,
     count: 1,
     hard: true,
-    free: false
+    free: false,
+    backendNames: ["completion_battlepass_interact_athena_hidden_star_07"]
   },
   "Quest:quest_br_eliminate_location_lazylinks": {
     name: "Eliminate opponents in Lazy Links",
@@ -414,7 +553,7 @@ module.exports = {
     count: 3,
     hard: true,
     free: false,
-    countPrefix: "completion_battlepass_killingblow_athena_player_lazylinks"
+    backendNames: ["completion_battlepass_killingblow_athena_player_lazylinks"]
   },
   "Quest:quest_br_use_trap": {
     name: "Place Traps",
@@ -422,7 +561,7 @@ module.exports = {
     count: 10,
     hard: false,
     free: true,
-    countPrefix: "completion_battlepass_place_athena_trap"
+    backendNames: ["completion_battlepass_place_athena_trap"]
   },
   "Quest:quest_br_interact_chests_location_wailingwoods": {
     name: "Search Chests in Wailing Woods",
@@ -430,8 +569,9 @@ module.exports = {
     count: 7,
     hard: false,
     free: true,
-    countPrefix:
+    backendNames: [
       "completion_battlepass_interact_athena_treasurechest_walingwoods"
+    ]
   },
   "Quest:quest_br_eliminate_weapon_shotgun": {
     name: "Shotgun Eliminations",
@@ -439,15 +579,15 @@ module.exports = {
     count: 4,
     hard: true,
     free: true,
-    countPrefix: "completion_battlepass_killingblow_athena_player_shotgun"
+    backendNames: ["completion_battlepass_killingblow_athena_player_shotgun"]
   },
   "Quest:quest_br_damage_pickaxe": {
-    name: "Deal damage with a Pickaxe to opponents",
+    name: "Deal damage with a pickaxe to opponents",
     reward: 5,
     count: 250,
     hard: false,
     free: false,
-    countPrefix: "completion_battlepass_damage_athena_player_pickax"
+    backendNames: ["completion_battlepass_Damage_athena_player_pickaxe"]
   },
   "Quest:quest_br_use_riftportal_differentlocations": {
     name: "Use a Rift at different Rift spawn locations",
@@ -455,14 +595,41 @@ module.exports = {
     count: 10,
     hard: false,
     free: false,
-    countPrefix: "completion_battlepass_athena_use_location_riftportal_"
+    backendNames: [
+      "completion_battlepass_athena_use_location_riftportal",
+      "completion_battlepass_athena_use_location_riftportal_01",
+      "completion_battlepass_athena_use_location_riftportal_02",
+      "completion_battlepass_athena_use_location_riftportal_03",
+      "completion_battlepass_athena_use_location_riftportal_04",
+      "completion_battlepass_athena_use_location_riftportal_05",
+      "completion_battlepass_athena_use_location_riftportal_06",
+      "completion_battlepass_athena_use_location_riftportal_07",
+      "completion_battlepass_athena_use_location_riftportal_08",
+      "completion_battlepass_athena_use_location_riftportal_09",
+      "completion_battlepass_athena_use_location_riftportal_10",
+      "completion_battlepass_athena_use_location_riftportal_11",
+      "completion_battlepass_athena_use_location_riftportal_12",
+      "completion_battlepass_athena_use_location_riftportal_13",
+      "completion_battlepass_athena_use_location_riftportal_14",
+      "completion_battlepass_athena_use_location_riftportal_15",
+      "completion_battlepass_athena_use_location_riftportal_16",
+      "completion_battlepass_athena_use_location_riftportal_17",
+      "completion_battlepass_athena_use_location_riftportal_18",
+      "completion_battlepass_athena_use_location_riftportal_19",
+      "completion_battlepass_athena_use_location_riftportal_20",
+      "completion_battlepass_athena_use_location_riftportal_21",
+      "completion_battlepass_athena_use_location_riftportal_22",
+      "completion_battlepass_athena_use_location_riftportal_23",
+      "completion_battlepass_athena_use_location_riftportal_24"
+    ]
   },
   "Quest:quest_br_interact_scavengerhunt_triangulate_04": {
     name: "Search between three oversized seats",
     reward: 10,
     count: 1,
     hard: true,
-    free: false
+    free: false,
+    backendNames: ["completion_battlepass_interact_athena_hidden_star_08"]
   },
   "Quest:quest_br_eliminate_questchain_01_a": {
     name: "Stage 1: Eliminate an opponent in Greasy Grove",
@@ -470,8 +637,9 @@ module.exports = {
     count: 1,
     hard: true,
     free: false,
-    countPrefix:
+    backendNames: [
       "completion_battlepass_killingblow_athena_player_questchain_greasygrove"
+    ]
   },
   "Quest:quest_br_eliminate_questchain_01_b": {
     name: "Stage 2: Eliminate an opponent in Lonely Lodge",
@@ -479,8 +647,9 @@ module.exports = {
     count: 1,
     hard: true,
     free: false,
-    countPrefix:
+    backendNames: [
       "completion_battlepass_killingblow_athena_player_questchain_lonelylodge"
+    ]
   },
   "Quest:quest_br_eliminate_questchain_01_c": {
     name: "Final Stage: Eliminate an opponent in Fatal Fields",
@@ -488,77 +657,1295 @@ module.exports = {
     count: 1,
     hard: true,
     free: false,
-    countPrefix:
+    backendNames: [
       "completion_battlepass_killingblow_athena_player_questchain_fatalfields"
+    ]
   },
   "Quest:quest_br_s5_gain_seasonxp_progressivea_01": {
     name: "Gain 10,000 XP",
     count: 10000,
-    countPrefix: "completion_athena_s5_season_gain_xp_progressive_a_01"
+    backendNames: []
   },
   "Quest:quest_br_s5_gain_seasonxp_progressivea_02": {
     name: "Gain 25,000 XP",
     count: 25000,
-    countPrefix: "completion_athena_s5_season_gain_xp_progressive_a_02"
+    backendNames: []
   },
   "Quest:quest_br_s5_gain_seasonxp_progressivea_03": {
     name: "Gain 50,000 XP",
     count: 50000,
-    countPrefix: "completion_athena_s5_season_gain_xp_progressive_a_03"
+    backendNames: []
   },
   "Quest:quest_br_s5_gain_seasonxp_progressivea_04": {
     name: "Gain 100,000 XP",
     count: 100000,
-    countPrefix: "completion_athena_s5_season_gain_xp_progressive_a_04"
+    backendNames: []
   },
   "Quest:quest_br_s5_gain_seasonxp_progressivea_05": {
     name: "Gain 200,000 XP",
     count: 200000,
-    countPrefix: "completion_athena_s5_season_gain_xp_progressive_a_05"
+    backendNames: []
   },
   "Quest:quest_br_s5_cumulative_collecttokens_01": {
     name: "Complete all challenges from any week",
     count: 1,
-    countPrefix: "completion_battlepass_season5_cumulative_token1"
+    backendNames: ["completion_battlepass_season5_cumulative_token1"]
   },
   "Quest:quest_br_s5_cumulative_collecttokens_02": {
     name: "Complete all challenges from any 2 different weeks",
     count: 2,
-    countPrefix: "completion_battlepass_season5_cumulative_token2"
+    backendNames: ["completion_battlepass_season5_cumulative_token2"]
   },
   "Quest:quest_br_s5_cumulative_collecttokens_03": {
     name: "Complete all challenges from any 3 different weeks",
     count: 3,
-    countPrefix: "completion_battlepass_season5_cumulative_token3"
+    backendNames: ["completion_battlepass_season5_cumulative_token3"]
   },
   "Quest:quest_br_s5_cumulative_collecttokens_04": {
     name: "Complete all challenges from any 4 different weeks",
     count: 4,
-    countPrefix: "completion_battlepass_season5_cumulative_token4"
+    backendNames: ["completion_battlepass_season5_cumulative_token4"]
   },
   "Quest:quest_br_s5_cumulative_collecttokens_05": {
     name: "Complete all challenges from any 5 different weeks",
     count: 5,
-    countPrefix: "completion_battlepass_season5_cumulative_token5"
+    backendNames: ["completion_battlepass_season5_cumulative_token5"]
   },
   "Quest:quest_br_s5_cumulative_collecttokens_06": {
     name: "Complete all challenges from any 6 different weeks",
     count: 6,
-    countPrefix: "completion_battlepass_season5_cumulative_token6"
+    backendNames: ["completion_battlepass_season5_cumulative_token6"]
   },
   "Quest:quest_br_s5_cumulative_collecttokens_07": {
     name: "Complete all challenges from any 7 different weeks",
     count: 7,
-    countPrefix: "completion_battlepass_season5_cumulative_token7"
+    backendNames: ["completion_battlepass_season5_cumulative_token7"]
   },
   "Quest:quest_br_s5_cumulative_collecttokens_08": {
     name: "Complete all challenges from any 8 different weeks",
     count: 8,
-    countPrefix: "completion_battlepass_season5_cumulative_token8"
+    backendNames: ["completion_battlepass_season5_cumulative_token8"]
   },
   "Quest:quest_br_s5_cumulative_collecttokens_09": {
     name: "Complete all challenges from any 9 different weeks",
     count: 9,
-    countPrefix: "completion_battlepass_season5_cumulative_token9"
+    backendNames: ["completion_battlepass_season5_cumulative_token9"]
+  },
+  "Quest:athenadailyquest_interactammocrate": {
+    name: "Search Ammo Boxes",
+    count: 7,
+    backendNames: []
+  },
+  "Quest:athenadailyquest_interacttreasurechest": {
+    name: "Search Chests",
+    count: 7,
+    backendNames: []
+  },
+  "Quest:athenadailyquest_playerelimination": {
+    name: "Eliminate Opponents",
+    count: 10,
+    backendNames: []
+  },
+  "Quest:athenadailyquest_playereliminationassaultrifles": {
+    name: "Assault Rifle Eliminations",
+    count: 5,
+    backendNames: []
+  },
+  "Quest:athenadailyquest_playereliminationpistols": {
+    name: "Pistol Eliminations",
+    count: 2,
+    backendNames: []
+  },
+  "Quest:athenadailyquest_playereliminationsmgs": {
+    name: "SMG Eliminations",
+    count: 2,
+    backendNames: []
+  },
+  "Quest:athenadailyquest_playereliminationshotguns": {
+    name: "Shotgun Eliminations",
+    count: 4,
+    backendNames: []
+  },
+  "Quest:athenadailyquest_playereliminationsniperrifles": {
+    name: "Sniper Rifle Eliminations",
+    count: 1,
+    backendNames: []
+  },
+  "Quest:athenadaily_friend": {
+    name: "Play a match with a friend",
+    count: 1,
+    backendNames: []
+  },
+  "Quest:athenadaily_outlive": {
+    name: "Outlive Opponents",
+    count: 300,
+    backendNames: []
+  },
+  "Quest:athenadaily_outlive_solo": {
+    name: "Outlive opponents in solo mode",
+    count: 150,
+    backendNames: []
+  },
+  "Quest:athenadaily_outlive_squad": {
+    name: "Outlive opponents in squad mode",
+    count: 150,
+    backendNames: []
+  },
+  "Quest:athenadaily_playmatches": {
+    name: "Play Matches",
+    count: 7,
+    backendNames: []
+  },
+  "Quest:athenadaily_solo_top25": {
+    name: "Place Top 25 in Solo",
+    count: 1,
+    backendNames: []
+  },
+  "Quest:athenadaily_solo_top50": {
+    name: "Place Top 50 in Solo",
+    count: 3,
+    backendNames: []
+  },
+  "Quest:athenadaily_squad_top12": {
+    name: "Place Top 12 in Squads",
+    count: 3,
+    backendNames: []
+  },
+  "Quest:athenadaily_squad_top6": {
+    name: "Place Top 6 in Squads",
+    count: 1,
+    backendNames: []
+  },
+  "Quest:athena_battlepass_outlive": {
+    name: "Outlive Opponents",
+    count: 300,
+    backendNames: []
+  },
+  "Quest:athena_battlepass_outlive_solo": {
+    name: "Outlive opponents in solo mode",
+    count: 150,
+    backendNames: []
+  },
+  "Quest:athena_battlepass_outlive_squad": {
+    name: "Outlive opponents in squad mode",
+    count: 150,
+    backendNames: []
+  },
+  "Quest:athena_battlepass_playmatches": {
+    name: "Play Matches",
+    count: 7,
+    backendNames: []
+  },
+  "Quest:athena_battlepass_questtrigger": {
+    name:
+      "A Battle Pass Challenge will be awarded every day if your Battle Pass Challenge slot is empty.",
+    count: 842286145,
+    backendNames: []
+  },
+  "Quest:athena_battlepass_quest_interactammocrate": {
+    name: "Search Ammo Boxes",
+    count: 7,
+    backendNames: []
+  },
+  "Quest:athena_battlepass_quest_interacttreasurechest": {
+    name: "Search Chests",
+    count: 7,
+    backendNames: []
+  },
+  "Quest:athena_battlepass_solo_top25": {
+    name: "Place Top 25 in Solo",
+    count: 1,
+    backendNames: []
+  },
+  "Quest:athena_battlepass_solo_top50": {
+    name: "Place Top 50 in Solo",
+    count: 5,
+    backendNames: []
+  },
+  "Quest:athena_battlepass_squad_top12": {
+    name: "Place Top 12 in Squads",
+    count: 5,
+    backendNames: []
+  },
+  "Quest:athena_battlepass_squad_top6": {
+    name: "Place Top 6 in Squads",
+    count: 1,
+    backendNames: []
+  },
+  "Quest:quest_br_collect_buildingresources_metal": {
+    name: "Harvest metal resources with a pickaxe",
+    count: 1500,
+    backendNames: ["completion_battlepass_collect_building_resources_metal"]
+  },
+  "Quest:quest_br_collect_buildingresources_stone": {
+    name: "Harvest stone resources with a pickaxe",
+    count: 1500,
+    backendNames: ["completion_battlepass_collect_building_resources_stone"]
+  },
+  "Quest:quest_br_collect_buildingresources_wood": {
+    name: "Harvest wood resources with a pickaxe",
+    count: 1500,
+    backendNames: ["completion_battlepass_collect_building_resources_wood"]
+  },
+  "Quest:quest_br_damage": {
+    name: "Deal damage to opponents",
+    count: 5000,
+    backendNames: ["completion_battlepass_damage_athena_player"]
+  },
+  "Quest:quest_br_damage_birthday": {
+    name: "Deal damage to opponents",
+    count: 1000,
+    backendNames: []
+  },
+  "Quest:quest_br_damage_crossbow": {
+    name: "Deal damage with Crossbows to opponents",
+    count: 300,
+    backendNames: ["completion_battlepass_damage_athena_player_crossbow"]
+  },
+  "Quest:quest_br_damage_enemy_buildings": {
+    name: "Deal damage to opponents structures",
+    count: 5000,
+    backendNames: ["completion_battlepass_Damage_athena_player_buildings"]
+  },
+  "Quest:quest_br_damage_explosiveweapon": {
+    name: "Deal damage with Explosive Weapons to opponents",
+    count: 500,
+    backendNames: ["completion_battlepass_damage_athena_player_explosives"]
+  },
+  "Quest:quest_br_damage_minigun": {
+    name: "Deal damage with Miniguns to opponents",
+    count: 300,
+    backendNames: ["completion_battlepass_damage_athena_player_minigun"]
+  },
+  "Quest:quest_br_damage_passenger_vehicle": {
+    name:
+      "Deal damage to opponents as the passenger of an ATK or shopping cart.",
+    count: 100,
+    backendNames: [
+      "completion_battlepass_damage_athena_player_passenger_vehicle"
+    ]
+  },
+  "Quest:quest_br_damage_pistol": {
+    name: "Deal damage with Pistols to opponents",
+    count: 500,
+    backendNames: ["completion_battlepass_damage_athena_player_pistol"]
+  },
+  "Quest:quest_br_damage_shotgun": {
+    name: "Deal damage with Shotguns to opponents",
+    count: 1000,
+    backendNames: ["completion_battlepass_Damage_athena_player_shotgun"]
+  },
+  "Quest:quest_br_damage_suppressedweapon": {
+    name: "Deal damage with Suppressed Weapons to opponents",
+    count: 500,
+    backendNames: [
+      "completion_battlepass_Damage_athena_player_suppressed_weapon"
+    ]
+  },
+  "Quest:quest_br_dance_scavengerhunt_birthdaycakes": {
+    name: "Dance in front of different Birthday Cakes",
+    count: 10,
+    backendNames: []
+  },
+  "Quest:quest_br_dance_scavengerhunt_cameras": {
+    name: "Dance in front of different film cameras",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_dance_athena_location_cameras",
+      "completion_battlepass_dance_athena_location_cameras_01",
+      "completion_battlepass_dance_athena_location_cameras_02",
+      "completion_battlepass_dance_athena_location_cameras_03",
+      "completion_battlepass_dance_athena_location_cameras_04",
+      "completion_battlepass_dance_athena_location_cameras_05",
+      "completion_battlepass_dance_athena_location_cameras_06",
+      "completion_battlepass_dance_athena_location_cameras_07",
+      "completion_battlepass_dance_athena_location_cameras_08",
+      "completion_battlepass_dance_athena_location_cameras_09"
+    ]
+  },
+  "Quest:quest_br_dance_scavengerhunt_dancefloors": {
+    name: "Dance on different Dance Floors",
+    count: 3,
+    backendNames: [
+      "completion_battlepass_dance_athena_location_disco",
+      "completion_battlepass_dance_athena_location_disco_01",
+      "completion_battlepass_dance_athena_location_disco_02",
+      "completion_battlepass_dance_athena_location_disco_03",
+      "completion_battlepass_dance_athena_location_disco_04",
+      "completion_battlepass_dance_athena_location_disco_05",
+      "completion_battlepass_dance_athena_location_disco_06",
+      "completion_battlepass_dance_athena_location_disco_07",
+      "completion_battlepass_dance_athena_location_disco_08",
+      "completion_battlepass_dance_athena_location_disco_09"
+    ]
+  },
+  "Quest:quest_br_dance_scavengerhunt_danceoff": {
+    name: "Dance Off with another player near Loot Lake",
+    count: 1,
+    backendNames: ["completion_battlepass_dance_athena_scavengerhunt_platforms"]
+  },
+  "Quest:quest_br_dance_scavengerhunt_forbidden": {
+    name: "Dance in different forbidden locations",
+    count: 5,
+    backendNames: [
+      "completion_battlepass_dance_athena_location_forbidden",
+      "completion_battlepass_dance_athena_location_forbidden_01",
+      "completion_battlepass_dance_athena_location_forbidden_02",
+      "completion_battlepass_dance_athena_location_forbidden_03",
+      "completion_battlepass_dance_athena_location_forbidden_04",
+      "completion_battlepass_dance_athena_location_forbidden_05",
+      "completion_battlepass_dance_athena_location_forbidden_06",
+      "completion_battlepass_dance_athena_location_forbidden_07",
+      "completion_battlepass_dance_athena_location_forbidden_08",
+      "completion_battlepass_dance_athena_location_forbidden_09"
+    ]
+  },
+  "Quest:quest_br_dance_scavengerhunt_platforms": {
+    name: "Dance with others to raise the Disco Ball near Loot Lake",
+    count: 1,
+    backendNames: ["completion_battlepass_dance_athena_scavengerhunt_platforms"]
+  },
+  "Quest:quest_br_eliminate": {
+    name: "Eliminate Opponents",
+    count: 10,
+    backendNames: ["completion_battlepass_killingblow_athena_players_multigame"]
+  },
+  "Quest:quest_br_eliminate_consumable_bush": {
+    name: "Eliminations as a Bush",
+    count: 1,
+    backendNames: ["completion_battlepass_killingblow_athena_player_asbush"]
+  },
+  "Quest:quest_br_eliminate_location_anarchyacres": {
+    name: "Eliminate opponents in Anarchy Acres",
+    count: 3,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_anarchyacres"
+    ]
+  },
+  "Quest:quest_br_eliminate_location_dustydepot": {
+    name: "Eliminate opponents in Dusty Depot",
+    count: 3,
+    backendNames: ["completion_battlepass_killingblow_athena_player_dustydepot"]
+  },
+  "Quest:quest_br_eliminate_location_fatalfields": {
+    name: "Eliminate opponents in Fatal Fields",
+    count: 3,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_fatalfields"
+    ]
+  },
+  "Quest:quest_br_eliminate_location_flushfactory": {
+    name: "Eliminate opponents in Flush Factory",
+    count: 3,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_flushfactory"
+    ]
+  },
+  "Quest:quest_br_eliminate_location_greasygrove": {
+    name: "Eliminate opponents in Greasy Grove",
+    count: 3,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_greasygrove"
+    ]
+  },
+  "Quest:quest_br_eliminate_location_junkjunction": {
+    name: "Eliminate opponents in Junk Junction",
+    count: 5,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_junkyjunction"
+    ]
+  },
+  "Quest:quest_br_eliminate_location_lonelylodge": {
+    name: "Eliminate opponents in Lonely Lodge",
+    count: 5,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_lonelylodge"
+    ]
+  },
+  "Quest:quest_br_eliminate_location_lootlake": {
+    name: "Eliminate opponents in Loot Lake",
+    count: 5,
+    backendNames: ["completion_battlepass_killingblow_athena_player_lootlake"]
+  },
+  "Quest:quest_br_eliminate_location_luckylanding": {
+    name: "Eliminate opponents in Lucky Landing",
+    count: 3,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_luckylanding"
+    ]
+  },
+  "Quest:quest_br_eliminate_location_moistymire": {
+    name: "Eliminate opponents in Moisty Mire",
+    count: 5,
+    backendNames: ["completion_battlepass_killingblow_athena_player_moistymire"]
+  },
+  "Quest:quest_br_eliminate_location_pleasantpark": {
+    name: "Eliminate opponents in Pleasant Park",
+    count: 3,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_pleasantpark"
+    ]
+  },
+  "Quest:quest_br_eliminate_location_riskyreels": {
+    name: "Eliminate opponents in Risky Reels",
+    count: 3,
+    backendNames: ["completion_battlepass_killingblow_athena_player_riskyreels"]
+  },
+  "Quest:quest_br_eliminate_location_saltysprings": {
+    name: "Eliminate opponents in Salty Springs",
+    count: 3,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_saltysprings"
+    ]
+  },
+  "Quest:quest_br_eliminate_location_snobbyshores": {
+    name: "Eliminate opponents in Snobby Shores",
+    count: 3,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_snobbyshores"
+    ]
+  },
+  "Quest:quest_br_eliminate_location_tomatotemple": {
+    name: "Eliminate opponents in Tomato Temple",
+    count: 3,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_tomatotemple"
+    ]
+  },
+  "Quest:quest_br_eliminate_location_tomatotown": {
+    name: "Eliminate opponents in Tomato Town",
+    count: 3,
+    backendNames: ["completion_battlepass_killingblow_athena_player_tomatotown"]
+  },
+  "Quest:quest_br_eliminate_location_wailingwoods": {
+    name: "Eliminate opponents in Wailing Woods",
+    count: 5,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_wailingwoods"
+    ]
+  },
+  "Quest:quest_br_eliminate_questchain_02_a": {
+    name: "Stage 1: Eliminate an opponent in Pleasant Park",
+    count: 1,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_questchain_pleasantpark"
+    ]
+  },
+  "Quest:quest_br_eliminate_questchain_02_b": {
+    name: "Stage 2: Eliminate an opponent in Wailing Woods",
+    count: 1,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_questchain_wailingwoods"
+    ]
+  },
+  "Quest:quest_br_eliminate_questchain_02_c": {
+    name: "Final Stage: Eliminate an opponent in Lucky Landing",
+    count: 1,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_questchain_luckylanding"
+    ]
+  },
+  "Quest:quest_br_eliminate_singel_match_elemeinations": {
+    name: "Eliminations in a single match",
+    count: 5,
+    backendNames: ["completion_bAthenaMustCompleteInSingleMatch"]
+  },
+  "Quest:quest_br_eliminate_suppressedweapon": {
+    name: "Suppressed Weapon eliminations",
+    count: 3,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_with_suppressed_weapon"
+    ]
+  },
+  "Quest:quest_br_eliminate_trap": {
+    name: "Trap Eliminations",
+    count: 1,
+    backendNames: ["completion_battlepass_killingblow_athena_player_with_trap"]
+  },
+  "Quest:quest_br_eliminate_weapon_assaultrifle": {
+    name: "Assault Rifle Eliminations",
+    count: 5,
+    backendNames: ["completion_battlepass_killingblow_athena_player_assault"]
+  },
+  "Quest:quest_br_eliminate_weapon_crossbow": {
+    name: "Crossbow Eliminations",
+    count: 1,
+    backendNames: ["completion_battlepass_killingblow_athena_player_crossbow"]
+  },
+  "Quest:quest_br_eliminate_weapon_minigun": {
+    name: "Minigun Eliminations",
+    count: 4,
+    backendNames: ["completion_battlepass_killingblow_athena_player_minigun"]
+  },
+  "Quest:quest_br_eliminate_weapon_pickaxe": {
+    name: "Pickaxe Eliminations",
+    count: 1,
+    backendNames: ["completion_battlepass_killingblow_athena_player_pickaxe"]
+  },
+  "Quest:quest_br_heist_damage_diamondcarriers": {
+    name: "Deal damage to Jewel carrying opponents",
+    count: 500,
+    backendNames: [
+      "completion_ltm_heistbundle_damage_athena_player_withdiamond"
+    ]
+  },
+  "Quest:quest_br_heist_pickupdiamond_differentmatches": {
+    name: "Pick up a Jewel in different matches of The Getaway",
+    count: 5,
+    backendNames: [
+      "completion_ltm_heistbundle_athena_pickupdiamond_differentmatches"
+    ]
+  },
+  "Quest:quest_br_heist_play_matches": {
+    name: "Play matches of The Getaway",
+    count: 10,
+    backendNames: ["completion_ltm_heistbundle_athena_play_matches"]
+  },
+  "Quest:quest_br_interact_chestammoboxsupplydrop_singlematch": {
+    name: "Search a Chest, Ammo Box, & Supply Drop in a single match",
+    count: 0,
+    backendNames: [
+      "completion_bAthenaMustCompleteInSingleMatch",
+      "completion_battlepass_interact_athena_ammobox",
+      "completion_battlepass_interact_athena_supplydrop",
+      "completion_battlepass_interact_athena_treasurechest"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_anarchyacres": {
+    name: "Search Chests in Anarchy Acres",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_anarchyacres"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_dustydepot": {
+    name: "Search Chests in Dusty Depot",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_dustydepot"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_dustydivot": {
+    name: "Search Chests in Dusty Divot",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_dustydivot"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_greasygrove": {
+    name: "Search Chests in Greasy Grove",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_greasygrove"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_hauntedhills": {
+    name: "Search Chests in Haunted Hills",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_hauntedhills"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_luckylanding": {
+    name: "Search Chests in Lucky Landing",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_luckylanding"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_moistymire": {
+    name: "Search Chests in Moisty Mire",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_moistymire"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_pleasantpark": {
+    name: "Search Chests in Pleasant Park",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_pleasantpark"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_retailrow": {
+    name: "Search Chests in Retail Row",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_retailrow"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_riskyreels": {
+    name: "Search Chests in Risky Reels",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_riskyreels"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_saltysprings": {
+    name: "Search Chests in Salty Springs",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_saltysprings"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_shiftyshafts": {
+    name: "Search Chests in Shifty Shifts",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_shiftyshafts"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_tiltedtowers": {
+    name: "Search Chests in Tilted Towers",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_tiltedtowers"
+    ]
+  },
+  "Quest:quest_br_interact_chests_location_tomatotown": {
+    name: "Search Chests in Tomato Town",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_tomatotown"
+    ]
+  },
+  "Quest:quest_br_interact_chests_locations_different": {
+    name: "Search a Chest in different Named Locations",
+    count: 12,
+    backendNames: [
+      "completion_battlepass_interact_chest_athena_location_different_anarchyacres",
+      "completion_battlepass_interact_chest_athena_location_different_dustydepot",
+      "completion_battlepass_interact_chest_athena_location_different_fatalfields",
+      "completion_battlepass_interact_chest_athena_location_different_flushfactory",
+      "completion_battlepass_interact_chest_athena_location_different_greasygrove",
+      "completion_battlepass_interact_chest_athena_location_different_hauntedhills",
+      "completion_battlepass_interact_chest_athena_location_different_junkjunction",
+      "completion_battlepass_interact_chest_athena_location_different_lonelylodge",
+      "completion_battlepass_interact_chest_athena_location_different_lootlake",
+      "completion_battlepass_interact_chest_athena_location_different_luckylanding",
+      "completion_battlepass_interact_chest_athena_location_different_moistymire",
+      "completion_battlepass_interact_chest_athena_location_different_pleasantpark",
+      "completion_battlepass_interact_chest_athena_location_different_retailrow",
+      "completion_battlepass_interact_chest_athena_location_different_saltysprings",
+      "completion_battlepass_interact_chest_athena_location_different_shiftyshafts",
+      "completion_battlepass_interact_chest_athena_location_different_snobbyshores",
+      "completion_battlepass_interact_chest_athena_location_different_tiltedtowers",
+      "completion_battlepass_interact_chest_athena_location_different_tomatotown",
+      "completion_battlepass_interact_chest_athena_location_different_wailingwoods"
+    ]
+  },
+  "Quest:quest_br_interact_chests_questchain_02_a": {
+    name: "Stage 1: Search a Chest in Haunted Hills",
+    count: 1,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_questchain_hauntedhills"
+    ]
+  },
+  "Quest:quest_br_interact_chests_questchain_02_b": {
+    name: "Stage 2: Search a Chest in Shifty Shafts",
+    count: 1,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_questchain_shiftyshafts"
+    ]
+  },
+  "Quest:quest_br_interact_chests_questchain_02_c": {
+    name: "Stage 3: Search a Chest in Lazy Links",
+    count: 1,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_questchain_lazylinks"
+    ]
+  },
+  "Quest:quest_br_interact_chests_questchain_02_d": {
+    name: "Stage 4: Search a Chest in Tilted Towers",
+    count: 1,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_questchain_tiltedtowers"
+    ]
+  },
+  "Quest:quest_br_interact_chests_questchain_02_e": {
+    name: "Final Stage: Search a Chest in Risky Reels",
+    count: 1,
+    backendNames: [
+      "completion_battlepass_interact_athena_treasurechest_questchain_riskyreels"
+    ]
+  },
+  "Quest:quest_br_interact_chests_singlematch": {
+    name: "Search 7 Chests in a single match",
+    count: 7,
+    backendNames: [
+      "completion_bAthenaMustCompleteInSingleMatch",
+      "completion_battlepass_interact_athena_loot_chest_single_match"
+    ]
+  },
+  "Quest:quest_br_interact_fortnite": {
+    name: "Search F-O-R-T-N-I-T-E Letters",
+    count: 8,
+    backendNames: [
+      "completion_battlepass_interact_athena_FORTNITE_Letters",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_01",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_02",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_03",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_04",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_05",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_06",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_07",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_08",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_09"
+    ]
+  },
+  "Quest:quest_br_interact_forageditems": {
+    name: "Consume Apples or Mushrooms",
+    count: 20,
+    backendNames: ["completion_battlepass_interact_athena_forgeditems"]
+  },
+  "Quest:quest_br_interact_gnaughtygnomes": {
+    name: "Defuse Gnaughty Gnomes",
+    count: 3,
+    backendNames: ["completion_battlepass_interact_athena_gnaughty_gnome"]
+  },
+  "Quest:quest_br_interact_gnicegnomes": {
+    name: "Search Hungry Gnomes",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_gnice_gnome",
+      "completion_battlepass_interact_athena_gnice_gnome_01",
+      "completion_battlepass_interact_athena_gnice_gnome_02",
+      "completion_battlepass_interact_athena_gnice_gnome_03",
+      "completion_battlepass_interact_athena_gnice_gnome_04",
+      "completion_battlepass_interact_athena_gnice_gnome_05",
+      "completion_battlepass_interact_athena_gnice_gnome_06",
+      "completion_battlepass_interact_athena_gnice_gnome_07",
+      "completion_battlepass_interact_athena_gnice_gnome_08",
+      "completion_battlepass_interact_athena_gnice_gnome_09"
+    ]
+  },
+  "Quest:quest_br_interact_gravitystones": {
+    name: "Consume Hop Rocks",
+    count: 7,
+    backendNames: ["completion_battlepass_interact_athena_gravitystones"]
+  },
+  "Quest:quest_br_interact_jigsawpuzzle": {
+    name: "Search Jigsaw Puzzle Pieces in Basements",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_FORTNITE_Letters",
+      "completion_battlepass_interact_athena_pieces",
+      "completion_battlepass_interact_athena_pieces_01",
+      "completion_battlepass_interact_athena_pieces_02",
+      "completion_battlepass_interact_athena_pieces_03",
+      "completion_battlepass_interact_athena_pieces_04",
+      "completion_battlepass_interact_athena_pieces_05",
+      "completion_battlepass_interact_athena_pieces_06",
+      "completion_battlepass_interact_athena_pieces_07",
+      "completion_battlepass_interact_athena_pieces_08",
+      "completion_battlepass_interact_athena_pieces_09"
+    ]
+  },
+  "Quest:quest_br_interact_letters": {
+    name: "Search S-E-A-S-O-N-5 Letters",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_interact_athena_FORTNITE_Letters",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_01",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_02",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_03",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_04",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_05",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_06",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_07",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_08",
+      "completion_battlepass_interact_athena_FORTNITE_Letters_09"
+    ]
+  },
+  "Quest:quest_br_interact_rubberduckies": {
+    name: "Search Rubber Duckies",
+    count: 10,
+    backendNames: [
+      "completion_battlepass_interact_athena_rubberduckies",
+      "completion_battlepass_interact_athena_rubberduckies_01",
+      "completion_battlepass_interact_athena_rubberduckies_02",
+      "completion_battlepass_interact_athena_rubberduckies_03",
+      "completion_battlepass_interact_athena_rubberduckies_04",
+      "completion_battlepass_interact_athena_rubberduckies_05",
+      "completion_battlepass_interact_athena_rubberduckies_06",
+      "completion_battlepass_interact_athena_rubberduckies_07",
+      "completion_battlepass_interact_athena_rubberduckies_08",
+      "completion_battlepass_interact_athena_rubberduckies_09"
+    ]
+  },
+  "Quest:quest_br_interact_scavengerhunt_treasuremap_05": {
+    name: "Follow the treasure map found in Shifty Shafts",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_athena_hidden_star_09"]
+  },
+  "Quest:quest_br_interact_scavengerhunt_triangulate_05": {
+    name: "Search between a covered bridge, waterfall, and the 9th green",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_athena_hidden_star"]
+  },
+  "Quest:quest_br_land_bulleyes_different": {
+    name: "Land on different Bullseyes",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_athena_land_location_bullseye",
+      "completion_battlepass_athena_land_location_bullseye_01",
+      "completion_battlepass_athena_land_location_bullseye_02",
+      "completion_battlepass_athena_land_location_bullseye_03",
+      "completion_battlepass_athena_land_location_bullseye_04",
+      "completion_battlepass_athena_land_location_bullseye_05",
+      "completion_battlepass_athena_land_location_bullseye_06",
+      "completion_battlepass_athena_land_location_bullseye_07",
+      "completion_battlepass_athena_land_location_bullseye_08",
+      "completion_battlepass_athena_land_location_bullseye_09"
+    ]
+  },
+  "Quest:quest_br_land_locations_different": {
+    name: "Land at different Named Locations",
+    count: 10,
+    backendNames: [
+      "completion_battlepass_land_athena_location_anarchyacres",
+      "completion_battlepass_land_athena_location_dustydivot",
+      "completion_battlepass_land_athena_location_fatalfields",
+      "completion_battlepass_land_athena_location_flushfactory",
+      "completion_battlepass_land_athena_location_greasygrove",
+      "completion_battlepass_land_athena_location_hauntedhills",
+      "completion_battlepass_land_athena_location_junkjunction",
+      "completion_battlepass_land_athena_location_lonelylodge",
+      "completion_battlepass_land_athena_location_lootlake",
+      "completion_battlepass_land_athena_location_luckylanding",
+      "completion_battlepass_land_athena_location_moistymire",
+      "completion_battlepass_land_athena_location_pleasantpark",
+      "completion_battlepass_land_athena_location_retailrow",
+      "completion_battlepass_land_athena_location_riskyreels",
+      "completion_battlepass_land_athena_location_saltysprings",
+      "completion_battlepass_land_athena_location_shiftyshafts",
+      "completion_battlepass_land_athena_location_snobbyshores",
+      "completion_battlepass_land_athena_location_tiltedtowers",
+      "completion_battlepass_land_athena_location_tomatotown",
+      "completion_battlepass_land_athena_location_wailingwoods"
+    ]
+  },
+  "Quest:quest_br_levelup_seasonlevel_25": {
+    name: "Reach Season Level 25",
+    count: 25,
+    backendNames: []
+  },
+  "Quest:quest_br_levelup_seasonlevel_50": {
+    name: "Reach Season Level 50",
+    count: 25,
+    backendNames: []
+  },
+  "Quest:quest_br_levelup_seasonlevel_progressivea_01": {
+    name: "Reach Season Level 10",
+    count: 10,
+    backendNames: []
+  },
+  "Quest:quest_br_levelup_seasonlevel_progressivea_02": {
+    name: "Reach Season Level 20",
+    count: 20,
+    backendNames: []
+  },
+  "Quest:quest_br_levelup_seasonlevel_progressivea_03": {
+    name: "Reach Season Level 30",
+    count: 30,
+    backendNames: []
+  },
+  "Quest:quest_br_levelup_seasonlevel_progressivea_04": {
+    name: "Reach Season Level 40",
+    count: 40,
+    backendNames: []
+  },
+  "Quest:quest_br_levelup_seasonlevel_progressivea_05": {
+    name: "Reach Season Level 65",
+    count: 65,
+    backendNames: []
+  },
+  "Quest:quest_br_levelup_seasonlevel_progressiveb_01": {
+    name: "Reach Season Level 25",
+    count: 25,
+    backendNames: []
+  },
+  "Quest:quest_br_levelup_seasonlevel_progressiveb_02": {
+    name: "Reach Season Level 35",
+    count: 35,
+    backendNames: []
+  },
+  "Quest:quest_br_levelup_seasonlevel_progressiveb_03": {
+    name: "Reach Season Level 45",
+    count: 45,
+    backendNames: []
+  },
+  "Quest:quest_br_levelup_seasonlevel_progressiveb_04": {
+    name: "Reach Season Level 55",
+    count: 55,
+    backendNames: []
+  },
+  "Quest:quest_br_levelup_seasonlevel_progressiveb_05": {
+    name: "Reach Season Level 80",
+    count: 80,
+    backendNames: []
+  },
+  "Quest:quest_br_outlive": {
+    name: "Outlive Opponents",
+    count: 1000,
+    backendNames: ["completion_battlepass_athena_outlive_players"]
+  },
+  "Quest:quest_br_outlive_duo": {
+    name: "Outlive Opponents in Duo",
+    count: 1000,
+    backendNames: ["completion_battlepass_athena_outlive_players_duo"]
+  },
+  "Quest:quest_br_outlive_solo": {
+    name: "Outlive Opponents in Solo",
+    count: 1000,
+    backendNames: ["completion_battlepass_athena_outlive_players_solo"]
+  },
+  "Quest:quest_br_place_top10_solo": {
+    name: "Place Top 10 in Solo",
+    count: 3,
+    backendNames: ["completion_battlepass_athena_place_solo_top"]
+  },
+  "Quest:quest_br_place_top3_squad": {
+    name: "Place Top 3 in Squads",
+    count: 3,
+    backendNames: ["completion_battlepass_athena_place_squad_top"]
+  },
+  "Quest:quest_br_place_win": {
+    name: "Win a Match",
+    count: 1,
+    backendNames: ["completion_battlepass_athena_win_match"]
+  },
+  "Quest:quest_br_place_win_duo": {
+    name: "Win a Match in Duo",
+    count: 1,
+    backendNames: ["completion_battlepass_athena_win_duo"]
+  },
+  "Quest:quest_br_place_win_nostormdamage": {
+    name: "Win a Match without taking storm damage",
+    count: 10000,
+    backendNames: ["completion_battlepass_Damage_athena_player"]
+  },
+  "Quest:quest_br_place_win_solo": {
+    name: "Win a Match in Solo",
+    count: 1,
+    backendNames: ["completion_battlepass_Athena_win_solo"]
+  },
+  "Quest:quest_br_place_win_squad": {
+    name: "Win a Match in Squads",
+    count: 1,
+    backendNames: ["completion_battlepass_athena_win_squad"]
+  },
+  "Quest:quest_br_play": {
+    name: "Play Matches",
+    count: 50,
+    backendNames: ["completion_battlepass_athena_play_matches"]
+  },
+  "Quest:quest_br_play_birthday": {
+    name: "Play matches",
+    count: 14,
+    backendNames: []
+  },
+  "Quest:quest_br_play_min1elimination": {
+    name: "Play matches with at least one elimination",
+    count: 10,
+    backendNames: ["completion_battlepass_complete_athena_with_killingblow"]
+  },
+  "Quest:quest_br_play_min1friend": {
+    name: "Play matches with friends",
+    count: 10,
+    backendNames: ["completion_battlepass_athena_friend"]
+  },
+  "Quest:quest_br_revive": {
+    name: "Revive Players",
+    count: 5,
+    backendNames: ["completion_battlepass_athena_revive_player"]
+  },
+  "Quest:quest_br_s5_cumulative_quest1": {
+    name: "Find Secret Battlestar",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_s5_cumulative_quest_01"]
+  },
+  "Quest:quest_br_s5_cumulative_quest2": {
+    name: "Find Secret Battlestar",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_s5_cumulative_quest_02"]
+  },
+  "Quest:quest_br_s5_cumulative_quest3": {
+    name: "Find Secret Battlestar",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_s5_cumulative_quest_03"]
+  },
+  "Quest:quest_br_s5_cumulative_quest4": {
+    name: "Find Secret Battlestar",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_s5_cumulative_quest_04"]
+  },
+  "Quest:quest_br_s5_cumulative_quest5": {
+    name: "Find Secret Battlestar",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_s5_cumulative_quest_05"]
+  },
+  "Quest:quest_br_s5_cumulative_quest6": {
+    name: "Find Secret Battlestar",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_s5_cumulative_quest_06"]
+  },
+  "Quest:quest_br_s5_cumulative_quest7": {
+    name: "Find Secret Battlestar",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_s5_cumulative_quest_07"]
+  },
+  "Quest:quest_br_s5_cumulative_quest8": {
+    name: "Find Secret Banner",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_s5_cumulative_quest_08"]
+  },
+  "Quest:quest_br_s5_cumulative_quest9": {
+    name: "Find Secret Banner",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_s5_cumulative_quest_09"]
+  },
+  "Quest:quest_br_s5_gain_seasonxp_progressiveb_01": {
+    name: "Gain 35,000 XP",
+    count: 35000,
+    backendNames: []
+  },
+  "Quest:quest_br_s5_gain_seasonxp_progressiveb_02": {
+    name: "Gain 75,000 XP",
+    count: 75000,
+    backendNames: []
+  },
+  "Quest:quest_br_s5_gain_seasonxp_progressiveb_03": {
+    name: "Gain 125,000 XP",
+    count: 125000,
+    backendNames: []
+  },
+  "Quest:quest_br_s5_gain_seasonxp_progressiveb_04": {
+    name: "Gain 250,000 XP",
+    count: 250000,
+    backendNames: []
+  },
+  "Quest:quest_br_s5_gain_seasonxp_progressiveb_05": {
+    name: "Gain 500,000 XP",
+    count: 500000,
+    backendNames: []
+  },
+  "Quest:quest_br_scavengerhunt_weakspots": {
+    name: "TBD",
+    count: 1,
+    backendNames: ["completion_battlepass_scavengerhunt_weakspots_01"]
+  },
+  "Quest:quest_br_score_goals": {
+    name: "Score a goal on different pitches.",
+    count: 5,
+    backendNames: [
+      "completion_battlepass_athena_score_goals_01",
+      "completion_battlepass_athena_score_goals_02",
+      "completion_battlepass_athena_score_goals_03",
+      "completion_battlepass_athena_score_goals_04",
+      "completion_battlepass_athena_score_goals_05",
+      "completion_battlepass_athena_score_goals_06",
+      "completion_battlepass_athena_score_goals_07"
+    ]
+  },
+  "Quest:quest_br_score_stylepoints_vehicle": {
+    name: "Get Trick Points in a Shopping Cart or ATK",
+    count: 150000,
+    backendNames: ["completion_battlepass_athena_score_stylepoints_vehicle"]
+  },
+  "Quest:quest_br_shoot_jumpingfish": {
+    name: "Shoot Jumping Fish.",
+    count: 15,
+    backendNames: ["completion_battlepass_destroy_jumping_fish"]
+  },
+  "Quest:quest_br_skydive_rings": {
+    name: "Skydive through floating Rings",
+    count: 20,
+    backendNames: ["completion_battlepass_skydive_athena_rings"]
+  },
+  "Quest:quest_br_spray_specifictargets": {
+    name: "Spray over different Carbide or Omega Posters",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_spray_athena_heroposters",
+      "completion_battlepass_spray_athena_heroposters_01",
+      "completion_battlepass_spray_athena_heroposters_02",
+      "completion_battlepass_spray_athena_heroposters_03",
+      "completion_battlepass_spray_athena_heroposters_04",
+      "completion_battlepass_spray_athena_heroposters_05",
+      "completion_battlepass_spray_athena_heroposters_06",
+      "completion_battlepass_spray_athena_heroposters_07",
+      "completion_battlepass_spray_athena_heroposters_08",
+      "completion_battlepass_spray_athena_heroposters_09"
+    ]
+  },
+  "Quest:quest_br_tbd_hard": {
+    name: "TBD Hard",
+    count: 1,
+    backendNames: ["completion_battlepass_athena_tbd_hard"]
+  },
+  "Quest:quest_br_tbd_normal": {
+    name: "TBD Normal",
+    count: 1,
+    backendNames: ["completion_battlepass_athena_tbd_normal"]
+  },
+  "Quest:quest_br_use_atk": {
+    name: "Use an ATK (All Terrain Kart)",
+    count: 1,
+    backendNames: ["completion_battlepass_athena_use_golfcart"]
+  },
+  "Quest:quest_br_use_bush": {
+    name: "Use the Bush",
+    count: 1,
+    backendNames: ["completion_battlepass_use_item_bush"]
+  },
+  "Quest:quest_br_use_cozycampfire": {
+    name: "Place a Cozy Campfire",
+    count: 1,
+    backendNames: ["completion_battlepass_place_athena_camp_fire"]
+  },
+  "Quest:quest_br_use_jetpack": {
+    name: "Use a Jetpack",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_athena_jetpack"]
+  },
+  "Quest:quest_br_use_portafort": {
+    name: "Use a Port-a-Fort",
+    count: 1,
+    backendNames: ["completion_battlepass_interact_athena_portafort"]
+  },
+  "Quest:quest_br_use_shoppingcart": {
+    name: "Use a Shopping Cart",
+    count: 1,
+    backendNames: ["completion_battlepass_athena_use_shoppingcart"]
+  },
+  "Quest:quest_br_use_vendingmachine": {
+    name: "Use a Vending Machine",
+    count: 3,
+    backendNames: ["completion_battlepass_interact_athena_vendingmachine"]
+  },
+  "Quest:quest_br_visit_craters_singlematch": {
+    name: "Visit Meteorite Craters in a Single Match",
+    count: 3,
+    backendNames: [
+      "completion_bAthenaMustCompleteInSingleMatch",
+      "completion_battlepass_visit_athena_meteor_crater_01",
+      "completion_battlepass_visit_athena_meteor_crater_02",
+      "completion_battlepass_visit_athena_meteor_crater_03",
+      "completion_battlepass_visit_athena_meteor_crater_04",
+      "completion_battlepass_visit_athena_meteor_crater_05",
+      "completion_battlepass_visit_athena_meteor_crater_06",
+      "completion_battlepass_visit_athena_meteor_crater_07",
+      "completion_battlepass_visit_athena_meteor_crater_08",
+      "completion_battlepass_visit_athena_meteor_crater_09"
+    ]
+  },
+  "Quest:quest_br_visit_gasstations_singlematch": {
+    name: "Visit different Gas Stations in a single match",
+    count: 0,
+    backendNames: [
+      "completion_bAthenaMustCompleteInSingleMatch",
+      "completion_battlepass_visit_athena_location_gas_station",
+      "completion_battlepass_visit_athena_location_gas_station_01",
+      "completion_battlepass_visit_athena_location_gas_station_02",
+      "completion_battlepass_visit_athena_location_gas_station_03",
+      "completion_battlepass_visit_athena_location_gas_station_04",
+      "completion_battlepass_visit_athena_location_gas_station_05",
+      "completion_battlepass_visit_athena_location_gas_station_06",
+      "completion_battlepass_visit_athena_location_gas_station_07",
+      "completion_battlepass_visit_athena_location_gas_station_08",
+      "completion_battlepass_visit_athena_location_gas_station_09"
+    ]
+  },
+  "Quest:quest_br_visit_icecreamtrucks_different": {
+    name: "Visit different Ice Cream Trucks",
+    count: 5,
+    backendNames: [
+      "completion_battlepass_visit_athena_location_icream",
+      "completion_battlepass_visit_athena_location_icream_01",
+      "completion_battlepass_visit_athena_location_icream_02",
+      "completion_battlepass_visit_athena_location_icream_03",
+      "completion_battlepass_visit_athena_location_icream_04",
+      "completion_battlepass_visit_athena_location_icream_05",
+      "completion_battlepass_visit_athena_location_icream_06",
+      "completion_battlepass_visit_athena_location_icream_07",
+      "completion_battlepass_visit_athena_location_icream_08",
+      "completion_battlepass_visit_athena_location_icream_09"
+    ]
+  },
+  "Quest:quest_br_visit_mountainpeaks": {
+    name: "Summit different Mountains Peaks",
+    count: 10,
+    backendNames: [
+      "completion_battlepass_visit_athena_location_mountain_summit",
+      "completion_battlepass_visit_athena_location_mountain_summit_01",
+      "completion_battlepass_visit_athena_location_mountain_summit_02",
+      "completion_battlepass_visit_athena_location_mountain_summit_03",
+      "completion_battlepass_visit_athena_location_mountain_summit_04",
+      "completion_battlepass_visit_athena_location_mountain_summit_05",
+      "completion_battlepass_visit_athena_location_mountain_summit_06",
+      "completion_battlepass_visit_athena_location_mountain_summit_07",
+      "completion_battlepass_visit_athena_location_mountain_summit_08",
+      "completion_battlepass_visit_athena_location_mountain_summit_09"
+    ]
+  },
+  "Quest:quest_br_visit_scavengerhunt_llamafoxcrab": {
+    name: "Visit a Llama, Fox, and a Crab",
+    count: 0,
+    backendNames: [
+      "completion_battlepass_visit_location_crab",
+      "completion_battlepass_visit_location_fox",
+      "completion_battlepass_visit_location_llama"
+    ]
+  },
+  "Quest:quest_br_visit_scavengerhunt_stormcircles": {
+    name: "Visit the center of different Storm Circles in a single match.",
+    count: 3,
+    backendNames: [
+      "completion_bAthenaMustCompleteInSingleMatch",
+      "completion_battlepass_findcenter_location_stormcircle"
+    ]
+  },
+  "Quest:quest_br_visit_stoneheads": {
+    name: "Visit different Stone Heads",
+    count: 7,
+    backendNames: [
+      "completion_battlepass_visit_athena_location_stonehead_01",
+      "completion_battlepass_visit_athena_location_stonehead_02",
+      "completion_battlepass_visit_athena_location_stonehead_03",
+      "completion_battlepass_visit_athena_location_stonehead_04",
+      "completion_battlepass_visit_athena_location_stonehead_05",
+      "completion_battlepass_visit_athena_location_stonehead_06",
+      "completion_battlepass_visit_athena_location_stonehead_07"
+    ]
+  },
+  "Quest:quest_br_visit_tacoshops_singlematch": {
+    name: "Visit different Taco Shops in a single match",
+    count: 3,
+    backendNames: [
+      "completion_bAthenaMustCompleteInSingleMatch",
+      "completion_battlepass_visit_athena_taco_shop",
+      "completion_battlepass_visit_athena_taco_shop_01",
+      "completion_battlepass_visit_athena_taco_shop_02",
+      "completion_battlepass_visit_athena_taco_shop_03",
+      "completion_battlepass_visit_athena_taco_shop_04",
+      "completion_battlepass_visit_athena_taco_shop_05",
+      "completion_battlepass_visit_athena_taco_shop_06",
+      "completion_battlepass_visit_athena_taco_shop_07",
+      "completion_battlepass_visit_athena_taco_shop_08",
+      "completion_battlepass_visit_athena_taco_shop_09"
+    ]
+  },
+  "Quest:quest_br_watch_replay": {
+    name: "Watch a Match Replay",
+    count: 1,
+    backendNames: ["completion_battlepass_athena_watch_replay"]
+  },
+  "Quest:quest_eliminate_suppressedweapon": {
+    name: "Suppressed Weapon Eliminations",
+    count: 3,
+    backendNames: [
+      "completion_battlepass_killingblow_athena_player_suppressed_weapon"
+    ]
   }
 };

--- a/data/quests.js
+++ b/data/quests.js
@@ -395,7 +395,7 @@ module.exports = {
     free: false
   },
   "Quest:quest_br_interact_chests_questchain_01_e": {
-    name: "Stage 1: Search a Chest in Paradise Palms",
+    name: "Final Stage: Search a Chest in Paradise Palms",
     reward: 1,
     count: 1,
     hard: false,
@@ -474,18 +474,22 @@ module.exports = {
       "completion_battlepass_killingblow_athena_player_questchain_greasygrove"
   },
   "Quest:quest_br_eliminate_questchain_01_b": {
-    name: "Stage 2: Eliminate an opponent",
+    name: "Stage 2: Eliminate an opponent in Lonely Lodge",
     reward: 3,
     count: 1,
     hard: true,
-    free: false
+    free: false,
+    countPrefix:
+      "completion_battlepass_killingblow_athena_player_questchain_lonelylodge"
   },
   "Quest:quest_br_eliminate_questchain_01_c": {
-    name: "Stage 3: Eliminate an opponent",
+    name: "Final Stage: Eliminate an opponent in Fatal Fields",
     reward: 3,
     count: 1,
     hard: true,
-    free: false
+    free: false,
+    countPrefix:
+      "completion_battlepass_killingblow_athena_player_questchain_fatalfields"
   },
   "Quest:quest_br_s5_gain_seasonxp_progressivea_01": {
     name: "Gain 10,000 XP",

--- a/data/quests.js
+++ b/data/quests.js
@@ -1,0 +1,560 @@
+module.exports = {
+  "Quest:quest_br_damage_smg": {
+    name: "Deal damage with SMGs to opponents",
+    reward: 5,
+    count: 500,
+    hard: false,
+    free: true,
+    countPrefix: "completion_battlepass_damage_athena_player_smg"
+  },
+  "Quest:quest_br_interact_supplyllamas": {
+    name: "Search a Supply Llama",
+    reward: 5,
+    count: 1,
+    hard: false,
+    free: true
+  },
+  "Quest:quest_br_eliminate_thrownweapon": {
+    name: "Clinger, Stink Bomb, or Grenade Eliminations",
+    reward: 10,
+    count: 3,
+    hard: true,
+    free: true,
+    countPrefix:
+      "completion_battlepass_killingblow_athena_player_with_thrownweapon"
+  },
+  "Quest:quest_br_interact_chests_location_snobbyshores": {
+    name: "Search Chests in Snobby Shores",
+    reward: 5,
+    count: 7,
+    hard: false,
+    free: false,
+    countPrefix:
+      "completion_battlepass_interact_athena_treasurechest_snobbyshores"
+  },
+  "Quest:quest_br_interact_floating_object": {
+    name: "Search floating Lightning Bolts",
+    reward: 5,
+    count: 7,
+    hard: false,
+    free: false,
+    countPrefix: "completion_battlepass_athena_generic_collect_a_"
+  },
+  "Quest:quest_br_interact_scavengerhunt_treasuremap_01": {
+    name: "Follow the treasure map found in Risky Reels",
+    reward: 10,
+    count: 1,
+    hard: true,
+    free: false
+  },
+  "Quest:quest_br_eliminate_location_retailrow": {
+    name: "Eliminate opponents in Retail Row",
+    reward: 10,
+    count: 3,
+    hard: true,
+    free: false,
+    countPrefix: "completion_battlepass_killingblow_athena_player_retailrow"
+  },
+  "Quest:quest_br_damage_assaultrifle": {
+    name: "Deal damage with Assault Rifles to opponents",
+    reward: 5,
+    count: 1000,
+    hard: false,
+    free: true,
+    countPrefix: "completion_battlepass_damage_athena_player_asssult"
+  },
+  "Quest:quest_br_interact_ammoboxes_singlematch": {
+    name: "Search 7 Ammo Boxes in a single match",
+    reward: 5,
+    count: 7,
+    hard: false,
+    free: true,
+    countPrefix: "completion_athena_battlepass_loot_ammobox_singlematch"
+  },
+  "Quest:quest_br_eliminate_location_paradisepalms": {
+    name: "Eliminate opponents in Paradise Palms",
+    reward: 10,
+    count: 3,
+    hard: true,
+    free: true,
+    countPrefix: "completion_battlepass_killingblow_athena_player_paradisepalms"
+  },
+  "Quest:quest_br_score_baskets": {
+    name: "Score a 3 point shot at different basketball courts",
+    reward: 5,
+    count: 5,
+    hard: false,
+    free: false,
+    countPrefix: "completion_battlepass_athena_score_basket_"
+  },
+  "Quest:quest_br_interact_chests_location_lootlake": {
+    name: "Search Chests in Loot Lake",
+    reward: 5,
+    count: 7,
+    hard: false,
+    free: false,
+    countPrefix: "completion_battlepass_interact_athena_treasurechest_lootlake"
+  },
+  "Quest:quest_br_interact_scavengerhunt_triangulate_01": {
+    name: "Search between an Oasis, Rock Archway, and Dinosaurs",
+    reward: 10,
+    count: 1,
+    hard: true,
+    free: false
+  },
+  "Quest:quest_br_eliminate_weapon_sniperrifle": {
+    name: "Sniper Rifle Eliminations",
+    reward: 10,
+    count: 2,
+    hard: true,
+    free: false,
+    countPrefix: "completion_battlepass_killingblow_athena_player_sniper"
+  },
+  "Quest:quest_br_damage_singlematch": {
+    name: "Deal damage to opponents in a single match",
+    reward: 5,
+    count: 500,
+    hard: false,
+    free: true,
+    countPrefix: "completion_battlepass_damage_athena_player_single_match"
+  },
+  "Quest:quest_br_use_launchpad": {
+    name: "Use a Launchpad",
+    reward: 5,
+    count: 1,
+    hard: false,
+    free: true
+  },
+  "Quest:quest_br_interact_scavengerhunt_treasuremap_02": {
+    name: "Follow the treasure map found in Flush Factory",
+    reward: 10,
+    count: 1,
+    hard: true,
+    free: true
+  },
+  "Quest:quest_br_interact_chests_location_fatalfields": {
+    name: "Search Chests in Fatal Fields",
+    reward: 5,
+    count: 7,
+    hard: false,
+    free: false,
+    countPrefix:
+      "completion_battlepass_interact_athena_treasurechest_fatalfields"
+  },
+  "Quest:quest_br_destroy_specifictargets": {
+    name: "Shoot a Clay Pigeon at different locations",
+    reward: 5,
+    count: 5,
+    hard: false,
+    free: false,
+    countPrefix: "completion_battlepass_destroy_specifictargets_"
+  },
+  "Quest:quest_br_eliminate_location_hauntedhills": {
+    name: "Eliminate opponents in Haunted Hills",
+    reward: 10,
+    count: 5,
+    hard: true,
+    free: false,
+    countPrefix: "completion_battlepass_killingblow_athena_player_hauntedhills"
+  },
+  "Quest:quest_br_eliminate_explosiveweapon": {
+    name: "Explosive Weapon Eliminations",
+    reward: 10,
+    count: 3,
+    hard: true,
+    free: false,
+    countPrefix:
+      "completion_battlepass_killingblow_athena_player_with_explosives"
+  },
+  "Quest:quest_br_build_structures": {
+    name: "Build Structures",
+    reward: 5,
+    count: 250,
+    hard: false,
+    free: true,
+    countPrefix: "completion_battlepass_build_athena_structures_any"
+  },
+  "Quest:quest_br_touch_flamingrings_vehicle": {
+    name: "Jump through flaming hoops with a Shopping Cart or ATK",
+    reward: 5,
+    count: 5,
+    hard: false,
+    free: true,
+    countPrefix: "completion_battlepass_touch_flamingrings_vehicle_"
+  },
+  "Quest:quest_br_eliminate_location_dustydivot": {
+    name: "Eliminate opponents in Dusty Divot",
+    reward: 10,
+    count: 3,
+    hard: true,
+    free: true,
+    countPrefix: "completion_battlepass_killingblow_athena_player_dustydivot"
+  },
+  "Quest:quest_br_damage_sniperrifle": {
+    name: "Deal damage with Sniper Rifles to opponents",
+    reward: 5,
+    count: 500,
+    hard: false,
+    free: false,
+    countPrefix: "completion_battlepass_damage_athena_player_sniper"
+  },
+  "Quest:quest_br_interact_chests_location_flushfactory": {
+    name: "Search Chests in Flush Factory",
+    reward: 5,
+    count: 7,
+    hard: false,
+    free: false,
+    countPrefix:
+      "completion_battlepass_interact_athena_treasurechest_flushfactory"
+  },
+  "Quest:quest_br_interact_scavengerhunt_triangulate_02": {
+    name: "Search between a Gas Station, Soccer Pitch, and Stunt Mountain",
+    reward: 10,
+    count: 1,
+    hard: true,
+    free: false
+  },
+  "Quest:quest_br_eliminate_weapon_pistol": {
+    name: "Pistol Eliminations",
+    reward: 10,
+    count: 3,
+    hard: true,
+    free: false,
+    countPrefix: "completion_battlepass_killingblow_athena_player_pistol"
+  },
+  "Quest:quest_br_interact_chests_location_junkjunction": {
+    name: "Search Chests in Junk Junction",
+    reward: 5,
+    count: 7,
+    hard: false,
+    free: true,
+    countPrefix:
+      "completion_battlepass_interact_athena_treasurechest_junkjunction"
+  },
+  "Quest:quest_br_use_riftportals": {
+    name: "Use Rifts or Rifts-To-Go",
+    reward: 5,
+    count: 3,
+    hard: false,
+    free: true,
+    countPrefix: "completion_battlepass_touch_athena_riftportal"
+  },
+  "Quest:quest_br_eliminate_singlematch": {
+    name: "Eliminate Opponents In a Single Match",
+    reward: 10,
+    count: 3,
+    hard: true,
+    free: true,
+    countPrefix: "completion_battlepass_killingblow_athena_players"
+  },
+  "Quest:quest_br_damage_thrownweapons": {
+    name: "Deal damage to players with a Clinger, Stink Bomb, or Grenade",
+    reward: 5,
+    count: 300,
+    hard: false,
+    free: false,
+    countPrefix: "completion_battlepass_damage_athena_player_thrownweapon"
+  },
+  "Quest:quest_br_score_teetogreen": {
+    name: "Hit a golf ball from tee to green on different holes",
+    reward: 5,
+    count: 5,
+    hard: false,
+    free: false,
+    countPrefix: "completion_battlepass_athena_score_hole_"
+  },
+  "Quest:quest_br_interact_scavengerhunt_treasuremap_03": {
+    name: "Follow the treasure map found in Snobby Shores",
+    reward: 10,
+    count: 1,
+    hard: true,
+    free: false
+  },
+  "Quest:quest_br_eliminate_location_shiftyshafts": {
+    name: "Eliminate opponents in Shifty Shafts",
+    reward: 10,
+    count: 3,
+    hard: true,
+    free: false,
+    countPrefix: "completion_battlepass_killingblow_athena_player_shiftyshafts"
+  },
+  "Quest:quest_br_damage_headshot": {
+    name: "Deal Headshot Damage to opponents",
+    reward: 5,
+    count: 500,
+    hard: false,
+    free: true,
+    countPrefix: "completion_battlepass_damage_athena_player_head_shots"
+  },
+  "Quest:quest_br_collect_buildingresources": {
+    name: "Harvest building resources with a pickaxe",
+    reward: 5,
+    count: 3000,
+    hard: false,
+    free: true,
+    countPrefix: "completion_battlepass_collect_building_resources"
+  },
+  "Quest:quest_br_interact_scavengerhunt_triangulate_03": {
+    name: "Search where the Stone Heads are looking",
+    reward: 10,
+    count: 1,
+    hard: true,
+    free: true
+  },
+  "Quest:quest_br_interact_chests_location_lonelylodge": {
+    name: "Search Chests in Lonely Lodge",
+    reward: 5,
+    count: 7,
+    hard: false,
+    free: false,
+    countPrefix:
+      "completion_battlepass_interact_athena_treasurechest_lonelylodge"
+  },
+  "Quest:quest_br_timed_trials": {
+    name: "Complete timed trials",
+    reward: 5,
+    count: 5,
+    hard: false,
+    free: false,
+    countPrefix: "completion_battlepass_complete_timed_trials_"
+  },
+  "Quest:quest_br_eliminate_weapon_minigunlmg": {
+    name: "Minigun or Light Machine Gun Eliminations",
+    reward: 10,
+    count: 2,
+    hard: true,
+    free: false,
+    countPrefix: "completion_battlepass_killingblow_athena_player_minigunlmg"
+  },
+  "Quest:quest_br_eliminate_location_tiltedtowers": {
+    name: "Eliminate opponents in Tilted Towers",
+    reward: 10,
+    count: 3,
+    hard: true,
+    free: false,
+    countPrefix: "completion_battlepass_killingblow_athena_player_tiltedtowers"
+  },
+  "Quest:quest_br_visit_namedlocations_singlematch": {
+    name: "Visit different Named Locations in a single match",
+    reward: 5,
+    count: 4,
+    hard: false,
+    free: true,
+    countPrefix: "completion_battlepass_visit_athena_location_"
+  },
+  "Quest:quest_br_interact_supplydrops": {
+    name: "Search Supply Drops",
+    reward: 5,
+    count: 3,
+    hard: false,
+    free: true,
+    countPrefix: "completion_battlepass_interact_athena_supply_drop"
+  },
+  "Quest:quest_br_eliminate_weapon_smg": {
+    name: "SMG Eliminations",
+    reward: 10,
+    count: 3,
+    hard: true,
+    free: true,
+    countPrefix: "completion_battlepass_killingblow_athena_player_smg"
+  },
+  "Quest:quest_br_damage_enemy_buildings_c4": {
+    name: "Deal damage to opponents structures with Remote Explosives",
+    reward: 5,
+    count: 8000,
+    hard: false,
+    free: false,
+    countPrefix: "completion_battlepass_damage_athena_player_buildings_c4"
+  },
+  "Quest:quest_br_interact_chests_questchain_01_a": {
+    name: "Stage 1: Search a Chest in Pleasant Park",
+    reward: 1,
+    count: 1,
+    hard: false,
+    free: false
+  },
+  "Quest:quest_br_interact_chests_questchain_01_b": {
+    name: "Stage 2: Search a Chest in Retail Row",
+    reward: 1,
+    count: 1,
+    hard: false,
+    free: false
+  },
+  "Quest:quest_br_interact_chests_questchain_01_c": {
+    name: "Stage 3: Search a Chest in Lucky Landing",
+    reward: 1,
+    count: 1,
+    hard: false,
+    free: false
+  },
+  "Quest:quest_br_interact_chests_questchain_01_d": {
+    name: "Stage 4: Search a Chest in Greasy Grove",
+    reward: 1,
+    count: 1,
+    hard: false,
+    free: false
+  },
+  "Quest:quest_br_interact_chests_questchain_01_e": {
+    name: "Stage 1: Search a Chest in Paradise Palms",
+    reward: 1,
+    count: 1,
+    hard: false,
+    free: false
+  },
+  "Quest:quest_br_interact_scavengerhunt_treasuremap_04": {
+    name: "Follow the treasure map found in Dusty Divot",
+    reward: 10,
+    count: 1,
+    hard: true,
+    free: false
+  },
+  "Quest:quest_br_eliminate_location_lazylinks": {
+    name: "Eliminate opponents in Lazy Links",
+    reward: 10,
+    count: 3,
+    hard: true,
+    free: false,
+    countPrefix: "completion_battlepass_killingblow_athena_player_lazylinks"
+  },
+  "Quest:quest_br_use_trap": {
+    name: "Place Traps",
+    reward: 5,
+    count: 10,
+    hard: false,
+    free: true,
+    countPrefix: "completion_battlepass_place_athena_trap"
+  },
+  "Quest:quest_br_interact_chests_location_wailingwoods": {
+    name: "Search Chests in Wailing Woods",
+    reward: 5,
+    count: 7,
+    hard: false,
+    free: true,
+    countPrefix:
+      "completion_battlepass_interact_athena_treasurechest_walingwoods"
+  },
+  "Quest:quest_br_eliminate_weapon_shotgun": {
+    name: "Shotgun Eliminations",
+    reward: 10,
+    count: 4,
+    hard: true,
+    free: true,
+    countPrefix: "completion_battlepass_killingblow_athena_player_shotgun"
+  },
+  "Quest:quest_br_damage_pickaxe": {
+    name: "Deal damage with a Pickaxe to opponents",
+    reward: 5,
+    count: 250,
+    hard: false,
+    free: false,
+    countPrefix: "completion_battlepass_damage_athena_player_pickax"
+  },
+  "Quest:quest_br_use_riftportal_differentlocations": {
+    name: "Use a Rift at different Rift spawn locations",
+    reward: 5,
+    count: 10,
+    hard: false,
+    free: false,
+    countPrefix: "completion_battlepass_athena_use_location_riftportal_"
+  },
+  "Quest:quest_br_interact_scavengerhunt_triangulate_04": {
+    name: "Search between three oversized seats",
+    reward: 10,
+    count: 1,
+    hard: true,
+    free: false
+  },
+  "Quest:quest_br_eliminate_questchain_01_a": {
+    name: "Stage 1: Eliminate an opponent in Greasy Grove",
+    reward: 3,
+    count: 1,
+    hard: true,
+    free: false,
+    countPrefix:
+      "completion_battlepass_killingblow_athena_player_questchain_greasygrove"
+  },
+  "Quest:quest_br_eliminate_questchain_01_b": {
+    name: "Stage 2: Eliminate an opponent",
+    reward: 3,
+    count: 1,
+    hard: true,
+    free: false
+  },
+  "Quest:quest_br_eliminate_questchain_01_c": {
+    name: "Stage 3: Eliminate an opponent",
+    reward: 3,
+    count: 1,
+    hard: true,
+    free: false
+  },
+  "Quest:quest_br_s5_gain_seasonxp_progressivea_01": {
+    name: "Gain 10,000 XP",
+    count: 10000,
+    countPrefix: "completion_athena_s5_season_gain_xp_progressive_a_01"
+  },
+  "Quest:quest_br_s5_gain_seasonxp_progressivea_02": {
+    name: "Gain 25,000 XP",
+    count: 25000,
+    countPrefix: "completion_athena_s5_season_gain_xp_progressive_a_02"
+  },
+  "Quest:quest_br_s5_gain_seasonxp_progressivea_03": {
+    name: "Gain 50,000 XP",
+    count: 50000,
+    countPrefix: "completion_athena_s5_season_gain_xp_progressive_a_03"
+  },
+  "Quest:quest_br_s5_gain_seasonxp_progressivea_04": {
+    name: "Gain 100,000 XP",
+    count: 100000,
+    countPrefix: "completion_athena_s5_season_gain_xp_progressive_a_04"
+  },
+  "Quest:quest_br_s5_gain_seasonxp_progressivea_05": {
+    name: "Gain 200,000 XP",
+    count: 200000,
+    countPrefix: "completion_athena_s5_season_gain_xp_progressive_a_05"
+  },
+  "Quest:quest_br_s5_cumulative_collecttokens_01": {
+    name: "Complete all challenges from any week",
+    count: 1,
+    countPrefix: "completion_battlepass_season5_cumulative_token1"
+  },
+  "Quest:quest_br_s5_cumulative_collecttokens_02": {
+    name: "Complete all challenges from any 2 different weeks",
+    count: 2,
+    countPrefix: "completion_battlepass_season5_cumulative_token2"
+  },
+  "Quest:quest_br_s5_cumulative_collecttokens_03": {
+    name: "Complete all challenges from any 3 different weeks",
+    count: 3,
+    countPrefix: "completion_battlepass_season5_cumulative_token3"
+  },
+  "Quest:quest_br_s5_cumulative_collecttokens_04": {
+    name: "Complete all challenges from any 4 different weeks",
+    count: 4,
+    countPrefix: "completion_battlepass_season5_cumulative_token4"
+  },
+  "Quest:quest_br_s5_cumulative_collecttokens_05": {
+    name: "Complete all challenges from any 5 different weeks",
+    count: 5,
+    countPrefix: "completion_battlepass_season5_cumulative_token5"
+  },
+  "Quest:quest_br_s5_cumulative_collecttokens_06": {
+    name: "Complete all challenges from any 6 different weeks",
+    count: 6,
+    countPrefix: "completion_battlepass_season5_cumulative_token6"
+  },
+  "Quest:quest_br_s5_cumulative_collecttokens_07": {
+    name: "Complete all challenges from any 7 different weeks",
+    count: 7,
+    countPrefix: "completion_battlepass_season5_cumulative_token7"
+  },
+  "Quest:quest_br_s5_cumulative_collecttokens_08": {
+    name: "Complete all challenges from any 8 different weeks",
+    count: 8,
+    countPrefix: "completion_battlepass_season5_cumulative_token8"
+  },
+  "Quest:quest_br_s5_cumulative_collecttokens_09": {
+    name: "Complete all challenges from any 9 different weeks",
+    count: 9,
+    countPrefix: "completion_battlepass_season5_cumulative_token9"
+  }
+};

--- a/data/quests.js
+++ b/data/quests.js
@@ -1352,6 +1352,9 @@ module.exports = {
   "Quest:quest_br_interact_chests_questchain_02_a": {
     name: "Stage 1: Search a Chest in Haunted Hills",
     count: 1,
+    free: false,
+    hard: false,
+    reward: 1,
     backendNames: [
       "completion_battlepass_interact_athena_treasurechest_questchain_hauntedhills"
     ]
@@ -1359,6 +1362,9 @@ module.exports = {
   "Quest:quest_br_interact_chests_questchain_02_b": {
     name: "Stage 2: Search a Chest in Shifty Shafts",
     count: 1,
+    free: false,
+    hard: false,
+    reward: 1,
     backendNames: [
       "completion_battlepass_interact_athena_treasurechest_questchain_shiftyshafts"
     ]
@@ -1366,6 +1372,9 @@ module.exports = {
   "Quest:quest_br_interact_chests_questchain_02_c": {
     name: "Stage 3: Search a Chest in Lazy Links",
     count: 1,
+    free: false,
+    hard: false,
+    reward: 1,
     backendNames: [
       "completion_battlepass_interact_athena_treasurechest_questchain_lazylinks"
     ]
@@ -1373,6 +1382,9 @@ module.exports = {
   "Quest:quest_br_interact_chests_questchain_02_d": {
     name: "Stage 4: Search a Chest in Tilted Towers",
     count: 1,
+    free: false,
+    hard: false,
+    reward: 1,
     backendNames: [
       "completion_battlepass_interact_athena_treasurechest_questchain_tiltedtowers"
     ]
@@ -1380,6 +1392,9 @@ module.exports = {
   "Quest:quest_br_interact_chests_questchain_02_e": {
     name: "Final Stage: Search a Chest in Risky Reels",
     count: 1,
+    free: false,
+    hard: false,
+    reward: 1,
     backendNames: [
       "completion_battlepass_interact_athena_treasurechest_questchain_riskyreels"
     ]
@@ -1769,6 +1784,9 @@ module.exports = {
   "Quest:quest_br_score_stylepoints_vehicle": {
     name: "Get Trick Points in a Shopping Cart or ATK",
     count: 150000,
+    free: true,
+    hard: false,
+    reward: 5,
     backendNames: ["completion_battlepass_athena_score_stylepoints_vehicle"]
   },
   "Quest:quest_br_shoot_jumpingfish": {
@@ -1930,6 +1948,9 @@ module.exports = {
   "Quest:quest_br_visit_stoneheads": {
     name: "Visit different Stone Heads",
     count: 7,
+    free: false,
+    hard: false,
+    reward: 5,
     backendNames: [
       "completion_battlepass_visit_athena_location_stonehead_01",
       "completion_battlepass_visit_athena_location_stonehead_02",

--- a/data/quests.js
+++ b/data/quests.js
@@ -664,27 +664,27 @@ module.exports = {
   "Quest:quest_br_s5_gain_seasonxp_progressivea_01": {
     name: "Gain 10,000 XP",
     count: 10000,
-    backendNames: []
+    backendNames: ["completion_athena_s5_season_gain_xp_progressive_a_01"]
   },
   "Quest:quest_br_s5_gain_seasonxp_progressivea_02": {
     name: "Gain 25,000 XP",
     count: 25000,
-    backendNames: []
+    backendNames: ["completion_athena_s5_season_gain_xp_progressive_a_02"]
   },
   "Quest:quest_br_s5_gain_seasonxp_progressivea_03": {
     name: "Gain 50,000 XP",
     count: 50000,
-    backendNames: []
+    backendNames: ["completion_athena_s5_season_gain_xp_progressive_a_03"]
   },
   "Quest:quest_br_s5_gain_seasonxp_progressivea_04": {
     name: "Gain 100,000 XP",
     count: 100000,
-    backendNames: []
+    backendNames: ["completion_athena_s5_season_gain_xp_progressive_a_04"]
   },
   "Quest:quest_br_s5_gain_seasonxp_progressivea_05": {
     name: "Gain 200,000 XP",
     count: 200000,
-    backendNames: []
+    backendNames: ["completion_athena_s5_season_gain_xp_progressive_a_05"]
   },
   "Quest:quest_br_s5_cumulative_collecttokens_01": {
     name: "Complete all challenges from any week",

--- a/index.js
+++ b/index.js
@@ -132,6 +132,35 @@ class FortniteApi {
     });
   }
 
+  getCheatSheets() {
+    return new Promise((resolve, reject) => {
+      request({
+        url: "https://www.reddit.com/user/thesquatingdog/submitted.json",
+        json: true
+      })
+        .then(({ data: { children } }) => {
+          const maps = children
+            .map(({ data }) => data)
+            .filter(({ title }) => title.includes("Season 5, Week "))
+            .filter((obj, pos, arr) => {
+              return arr.map(mapObj => mapObj.title).indexOf(obj.title) === pos;
+            })
+            .map(({ title, preview: { images } }) => ({
+              title: title.replace(" (All Inclusive Cheat Sheet)", ""),
+              week: parseInt(
+                title
+                  .replace("Season 5, Week ", "")
+                  .replace(" Challenges (All Inclusive Cheat Sheet)", "")
+              ),
+              url: images[0].source.url
+            }))
+            .reverse();
+          resolve(maps);
+        })
+        .catch(e => reject(e));
+    });
+  }
+
   getLoggedInProfile() {
     return new Promise((resolve, reject) => {
       request({

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ class FortniteApi {
     });
   }
 
-  getChallenges() {
+  getLoggedInProfile() {
     return new Promise((resolve, reject) => {
       request({
         url: EndPoint.challenges(this.account_id),

--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ class FortniteApi {
                         .filter(i => i)
                         .reduce((a, b) => a + b, 0);
 
-                      delete quest.countPrefix;
+                      delete quest.backendNames;
 
                       return {
                         complete,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,35 @@
-const request = require("request-promise");
+const fetch = require("node-fetch");
 const EndPoint = require("./tools/endpoint");
 const Stats = require("./tools/stats");
 const quests = require("./data/quests");
+
+const request = ({ url, form: body, headers, method }) => {
+  if (method === "POST") {
+    return fetch(url, {
+      body: body
+        ? Object.entries(body)
+            .map(pair => pair.map(encodeURIComponent).join("="))
+            .join("&")
+        : "{}",
+      headers: {
+        ...headers,
+        "Content-Type": body
+          ? "application/x-www-form-urlencoded"
+          : "application/json"
+      },
+      method
+    }).then(data => {
+      return data.json();
+    });
+  } else {
+    return fetch(url, {
+      headers: {
+        ...headers
+      },
+      method
+    }).then(data => data.json());
+  }
+};
 
 class FortniteApi {
   constructor(credentials, options) {

--- a/index.js
+++ b/index.js
@@ -174,6 +174,10 @@ class FortniteApi {
                 .replace(
                   "ChallengeBundleSchedule:season5_free_schedule",
                   "Weekly Challenges"
+                )
+                .replace(
+                  "ChallengeBundleSchedule:schedule_ltm_heist",
+                  "High Stakes Challenges"
                 ),
               bundles: attributes.granted_bundles
                 .filter(challenge => challenge)
@@ -195,6 +199,10 @@ class FortniteApi {
                     .replace(
                       "ChallengeBundle:questbundle_s5_cumulative",
                       "Road Trip"
+                    )
+                    .replace(
+                      "ChallengeBundle:questbundle_ltm_heist",
+                      "High Stakes"
                     );
 
                   // This is bc weeks go to 10
@@ -232,28 +240,13 @@ class FortniteApi {
                       } = items[id];
                       const complete = quest_state === "Claimed";
                       const quest = quests[templateId] || {};
-                      const prefix = quest.countPrefix || "";
+                      const backendNames = quest.backendNames;
 
-                      let completedCount = attributes[prefix];
+                      const completedCount = backendNames
+                        .map(name => attributes[name])
+                        .filter(i => i)
+                        .reduce((a, b) => a + b, 0);
 
-                      if (!completedCount) {
-                        completedCount = complete ? 1 : 0;
-                      }
-
-                      if (prefix.length > 0 && prefix.slice(-1) === "_") {
-                        const keys = Object.keys(attributes).filter(attr =>
-                          attr.includes(prefix)
-                        );
-
-                        const count = keys
-                          .map(key => attributes[key])
-                          .reduce((a, b) => a + b);
-
-                        completedCount = count;
-                      }
-
-                      // this removes the countPrefix prop, since it's interal only
-                      // lol, what even are classes
                       delete quest.countPrefix;
 
                       return {
@@ -284,9 +277,7 @@ class FortniteApi {
             tier,
             tierExp,
             exp,
-            freeSeasonChallenges: challenges[0],
-            paidSeasonChallenges: challenges[1],
-            weeklyChallenges: challenges[2]
+            challenges
           });
         })
         .catch(err => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fortnite-api",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Fortnite API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fortnite-api",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "Fortnite API",
   "main": "index.js",
   "scripts": {
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/Jake-Ruston/fortnite#readme",
   "dependencies": {
-    "request": "^2.85.0",
+    "request": "^2.88.0",
     "request-promise": "^4.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fortnite-api",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "Fortnite API",
   "main": "index.js",
   "scripts": {

--- a/tools/endpoint.js
+++ b/tools/endpoint.js
@@ -1,58 +1,61 @@
 module.exports = {
-    OAUTH_TOKEN:
-        "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/token",
-    OAUTH_EXCHANGE:
-        "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/exchange",
-    OAUTH_VERIFY:
-        "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/verify?includePerms=true",
-    FortnitePVEInfo:
-        "https://fortnite-public-service-prod11.ol.epicgames.com/fortnite/api/game/v2/world/info",
-    FortniteStore:
-        "https://fortnite-public-service-prod11.ol.epicgames.com/fortnite/api/storefront/v2/catalog",
-    FortniteStatus:
-        "https://lightswitch-public-service-prod06.ol.epicgames.com/lightswitch/api/service/bulk/status?serviceId=Fortnite",
-    FortniteNews:
-        "https://fortnitecontent-website-prod07.ol.epicgames.com/content/api/pages/fortnite-game",
-    lookup: username => {
-        return (
-            "https://persona-public-service-prod06.ol.epicgames.com/persona/api/public/account/lookup?q=" +
-            encodeURI(username)
-        );
-    },
-    statsBR: (accountId, timeWindow) => {
-        return (
-            "https://fortnite-public-service-prod11.ol.epicgames.com/fortnite/api/stats/accountId/" +
-            accountId +
-            "/bulk/window/" +
-            (timeWindow || "alltime")
-        );
-    },
-    statsPVE: accountId => {
-        return (
-            "https://fortnite-public-service-prod11.ol.epicgames.com/fortnite/api/game/v2/profile/" +
-            accountId +
-            "/client/QueryProfile?profileId=collection_book_schematics0&rvn=-1"
-        );
-    },
-    killSession: token => {
-        return (
-            "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/sessions/kill/" +
-            token
-        );
-    },
-    leaderBoardScore: (plat, groupType) => {
-        return `https://fortnite-public-service-prod11.ol.epicgames.com/fortnite/api/leaderboards/type/global/stat/br_placetop1_${plat}_m0${groupType}/window/weekly?ownertype=1&pageNumber=0&itemsPerPage=50`;
-    },
-    displayNameFromIds: ids => {
-        return (
-            "https://account-public-service-prod03.ol.epicgames.com/account/api/public/account?accountId=" +
-            ids.join("&accountId=")
-        );
-    },
-    displayNameFromId: id => {
-        return (
-            "https://account-public-service-prod03.ol.epicgames.com/account/api/public/account?accountId=" +
-            id
-        );
-    }
+  OAUTH_TOKEN:
+    "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/token",
+  OAUTH_EXCHANGE:
+    "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/exchange",
+  OAUTH_VERIFY:
+    "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/verify?includePerms=true",
+  FortnitePVEInfo:
+    "https://fortnite-public-service-prod11.ol.epicgames.com/fortnite/api/game/v2/world/info",
+  FortniteStore:
+    "https://fortnite-public-service-prod11.ol.epicgames.com/fortnite/api/storefront/v2/catalog",
+  FortniteStatus:
+    "https://lightswitch-public-service-prod06.ol.epicgames.com/lightswitch/api/service/bulk/status?serviceId=Fortnite",
+  FortniteNews:
+    "https://fortnitecontent-website-prod07.ol.epicgames.com/content/api/pages/fortnite-game",
+  challenges: accountId => {
+    return `https://fortnite-public-service-prod-live-m.ol.epicgames.com/fortnite/api/game/v2/profile/${accountId}/client/QueryProfile?profileId=athena&rvn=-1`;
+  },
+  lookup: username => {
+    return (
+      "https://persona-public-service-prod06.ol.epicgames.com/persona/api/public/account/lookup?q=" +
+      encodeURI(username)
+    );
+  },
+  statsBR: (accountId, timeWindow) => {
+    return (
+      "https://fortnite-public-service-prod11.ol.epicgames.com/fortnite/api/stats/accountId/" +
+      accountId +
+      "/bulk/window/" +
+      (timeWindow || "alltime")
+    );
+  },
+  statsPVE: accountId => {
+    return (
+      "https://fortnite-public-service-prod11.ol.epicgames.com/fortnite/api/game/v2/profile/" +
+      accountId +
+      "/client/QueryProfile?profileId=collection_book_schematics0&rvn=-1"
+    );
+  },
+  killSession: token => {
+    return (
+      "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/sessions/kill/" +
+      token
+    );
+  },
+  leaderBoardScore: (plat, groupType) => {
+    return `https://fortnite-public-service-prod11.ol.epicgames.com/fortnite/api/leaderboards/type/global/stat/br_placetop1_${plat}_m0${groupType}/window/weekly?ownertype=1&pageNumber=0&itemsPerPage=50`;
+  },
+  displayNameFromIds: ids => {
+    return (
+      "https://account-public-service-prod03.ol.epicgames.com/account/api/public/account?accountId=" +
+      ids.join("&accountId=")
+    );
+  },
+  displayNameFromId: id => {
+    return (
+      "https://account-public-service-prod03.ol.epicgames.com/account/api/public/account?accountId=" +
+      id
+    );
+  }
 };


### PR DESCRIPTION
This adds profile / challenge lookup for the logged in user, the quest data is incomplete, but most of is there. Will need to update for each week. Staged challenges aren't returned if you haven't completed them it seems, so I am missing some mappings. Haven't tested with an account that doesn't have battle pass. Please give it a test, feel free to help add quest info.