### PR TITLE
Convenience methods to fetch User and BR Stats using session's account ID

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ class FortniteApi {
         this.expires_at = data.expires_at;
         this.access_token = data.access_token;
         this.refresh_token = data.refresh_token;
+        this.account_id = data.account_id;
       })
       .catch(() => {
         throw new Error("Error: Fatal Error Impossible to Renew Token");
@@ -106,6 +107,7 @@ class FortniteApi {
                   this.expires_at = res.data.expires_at;
                   this.access_token = res.data.access_token;
                   this.refresh_token = res.data.refresh_token;
+                  this.account_id = res.data.account_id;
                   this.intervalCheckToken = setInterval(() => {
                     this.checkToken();
                   }, 1000);
@@ -178,6 +180,11 @@ class FortniteApi {
           });
         });
     });
+  }
+
+  //Find User by authenticated User ID
+  lookupMe() {
+    return this.lookupById(this.account_id);
   }
 
   //Check if Player exist on the platform
@@ -308,6 +315,11 @@ class FortniteApi {
           });
         });
     });
+  }
+
+  //Battle Royale Stats from authenticated User ID
+  getMyStatsBR(platform, timeWindow) {
+    return this.getStatsBRFromID(this.account_id, platform, timeWindow);
   }
 
   //Get Fortnite Ingame News

--- a/test/index.js
+++ b/test/index.js
@@ -34,6 +34,13 @@ describe('Fornite API Tests', () => {
         });
     });
 
+    it('Lookup By authenticated User ID', (done) => {
+        fAPI.lookupMe().then((res) => {
+            assert.equal(typeof res, "object");
+            done();
+        });
+    });
+
     it('Check if Player exist', (done) => {
         fAPI.checkPlayer("Mirardes", "pc", "alltime").then((res) => {
             assert.equal(typeof res, "object");
@@ -50,6 +57,13 @@ describe('Fornite API Tests', () => {
 
     it('Get Battle Royal Stats from ID', (done) => {
         fAPI.getStatsBRFromID("6372c32ec81d4a0a9f6e79f0d5edc31a", "pc", "alltime").then((res) => {
+            assert.equal(typeof res, "object");
+            done();
+        });
+    });
+
+    it('Get Battle Royale Stats from authenticated User ID', (done) => {
+        fAPI.getMyStatsBR("pc", "alltime").then((res) => {
             assert.equal(typeof res, "object");
             done();
         });


### PR DESCRIPTION
I saw `account_id` in the token object and thought these two convenience methods could be nice additions