### PR TITLE
Fixed refreshToken using incorrect variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,11 +48,11 @@ class FortniteApi {
         method: "POST",
         responseType: "json"
       })
-      .then((data) => {
-        this.expires_at = data.expires_at;
-        this.access_token = data.access_token;
-        this.refresh_token = data.refresh_token;
-        this.account_id = data.account_id;
+      .then((res) => {
+        this.expires_at = res.data.expires_at;
+        this.access_token = res.data.access_token;
+        this.refresh_token = res.data.refresh_token;
+        this.account_id = res.data.account_id;
       })
       .catch(() => {
         throw new Error("Error: Fatal Error Impossible to Renew Token");


### PR DESCRIPTION
I noticed that the api would eventually stop working - getStatsBR would start returning "Player Not Found" after a few hours. I tried using killSession but that would also return "Impossible to kill the API. Please Try Again !". I noticed that refreshToken was using an incorrect variable that would corrupt the api data like access token, refresh token, etc by setting them to undefined due to assignments from an incorrect variable