### PR TITLE
Standardize ⚠ emoji in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ How to get these headers ?
 * You will see again a request with /account/api/oauth/token. Click on it and click after that on Inspectors get the header (Authorization header content and remove basic) => **This header is your Fortnite Client Token**
 * Stop Capture
 
-/!\ **Warning** /!\ (Thanks @MrPowerGamerBR)
+⚠ **Warning** ⚠ (Thanks @MrPowerGamerBR)
 
 To be sure that the API is working for you, you need to :
 


### PR DESCRIPTION
The ⚠ emoji was brought into the readme.me for the info section (see commit sha 8eb43dc1f4179851ac2904c56c6f327fee1a2591). Also use emoji for warning section in place of text representation `/!\`